### PR TITLE
Use public CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint-swift:
     name: Lint Swift code
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -20,7 +20,7 @@ jobs:
 
   license:
     name: Verify license headers
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -28,7 +28,7 @@ jobs:
 
   check-packed-files:
     name: Check package files
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     env:
       TERM: xterm
     steps:
@@ -41,7 +41,7 @@ jobs:
 
   test:
     name: Run jest tests
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -52,7 +52,7 @@ jobs:
 
   test-android:
     name: Run Android Tests
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### What are you trying to accomplish?

Uses public CI runners

### Before you deploy

- ~I have added tests to support my implementation~
- [x] I have read and agree with the contributing documentation [readme](/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](/.github/CODE_OF_CONDUCT.md)
- ~I have updated any documentation related to these changes.~
- ~I have updated the [README](/README.md) (if applicable).~
