### PR TITLE
Add support for international pricing in sample app

### DIFF
--- a/sample/@types/index.d.ts
+++ b/sample/@types/index.d.ts
@@ -45,12 +45,20 @@ export interface CartItem {
   };
 }
 
+export interface CartLineItem {
+  id: string;
+  merchandise: CartItem;
+  quantity: number;
+  cost: {
+    totalAmount: {
+      currencyCode: string;
+      amount: string;
+    };
+  };
+}
+
 export interface ShopifyCart {
   cost: CartCost;
-  lines: Edges<{
-    id: string;
-    merchandise: CartItem;
-    quantity: number;
-  }>;
+  lines: Edges<CartLineItem>;
   totalQuantity: number;
 }

--- a/sample/src/screens/CartScreen.tsx
+++ b/sample/src/screens/CartScreen.tsx
@@ -38,9 +38,10 @@ import Icon from 'react-native-vector-icons/Entypo';
 import {useShopifyCheckoutSheet} from '@shopify/checkout-sheet-kit';
 import useShopify from '../hooks/useShopify';
 
-import type {CartItem} from '../../@types';
+import type {CartItem, CartLineItem} from '../../@types';
 import {Colors, useTheme} from '../context/Theme';
 import {useCart} from '../context/Cart';
+import {currency} from '../utils';
 
 function CartScreen(): JSX.Element {
   const ShopifyCheckout = useShopifyCheckoutSheet();
@@ -122,7 +123,7 @@ function CartScreen(): JSX.Element {
           {data?.cart.lines.edges.map(({node}) => (
             <CartItem
               key={node.merchandise.id}
-              item={node.merchandise}
+              item={node}
               quantity={node.quantity}
               loading={addingToCart.has(node.id)}
               onRemove={() => removeFromCart(node.id)}
@@ -175,8 +176,8 @@ function price(value: {amount: string; currencyCode: string}) {
     return '-';
   }
 
-  const {amount} = value;
-  return `£${Number(amount).toFixed(2)}`;
+  const {amount, currencyCode} = value;
+  return currency(amount, currencyCode);
 }
 
 function CartItem({
@@ -185,7 +186,7 @@ function CartItem({
   onRemove,
   loading,
 }: {
-  item: CartItem;
+  item: CartLineItem;
   quantity: number;
   loading?: boolean;
   onRemove: () => void;
@@ -204,16 +205,20 @@ function CartItem({
         resizeMethod="resize"
         resizeMode="cover"
         style={styles.productImage}
-        alt={item.image?.altText}
-        source={{uri: item.image?.url}}
+        alt={item.merchandise.image?.altText}
+        source={{uri: item.merchandise.image?.url}}
       />
       <View style={styles.productText}>
         <View style={styles.productTextContainer}>
-          <Text style={styles.productTitle}>{item.product.title}</Text>
+          <Text style={styles.productTitle}>
+            {item.merchandise.product.title}
+          </Text>
           <Text style={styles.productDescription}>Quantity: {quantity}</Text>
         </View>
         <View>
-          <Text style={styles.productPrice}>{price(item?.price)}</Text>
+          <Text style={styles.productPrice}>
+            {price(item.cost?.totalAmount)}
+          </Text>
           <Pressable style={styles.removeButton} onPress={onRemove}>
             {loading ? (
               <ActivityIndicator size="small" />

--- a/sample/src/screens/CatalogScreen.tsx
+++ b/sample/src/screens/CatalogScreen.tsx
@@ -41,6 +41,7 @@ import {Colors, useTheme} from '../context/Theme';
 import {useCart} from '../context/Cart';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {RootStackParamList} from '../App';
+import {currency} from '../utils';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'CatalogScreen'>;
 
@@ -153,8 +154,7 @@ function Product({
         <View>
           <Text style={styles.productTitle}>{product.title}</Text>
           <Text style={styles.productPrice}>
-            £{Number(variant?.price.amount).toFixed(2)}{' '}
-            {variant?.price.currencyCode}
+            {currency(variant?.price.amount, variant?.price.currencyCode)}
           </Text>
         </View>
         <View style={styles.addToCartButtonContainer}>

--- a/sample/src/screens/ProductDetailsScreen.tsx
+++ b/sample/src/screens/ProductDetailsScreen.tsx
@@ -38,6 +38,7 @@ import {Colors, useTheme} from '../context/Theme';
 import {useCart} from '../context/Cart';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {RootStackParamList} from '../App';
+import {currency} from '../utils';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'ProductDetails'>;
 
@@ -110,7 +111,8 @@ function ProductDetails({
               <ActivityIndicator size="small" color="white" />
             ) : (
               <Text style={styles.addToCartButtonText}>
-                Add to cart &bull; £{Number(variant?.price.amount).toFixed(2)}
+                Add to cart &bull;{' '}
+                {currency(variant?.price.amount, variant?.price.currencyCode)}
               </Text>
             )}
           </Pressable>

--- a/sample/src/utils.ts
+++ b/sample/src/utils.ts
@@ -11,6 +11,7 @@ import {
   ZIP,
   PHONE,
 } from '@env';
+import {NativeModules, Platform} from 'react-native';
 import {AppConfig} from './context/Config';
 
 export function createBuyerIdentityCartInput(appConfig: AppConfig) {
@@ -37,4 +38,35 @@ export function createBuyerIdentityCartInput(appConfig: AppConfig) {
       },
     },
   };
+}
+
+export function getLocale(): string {
+  const fallbackLocale = 'en_CA';
+
+  return (
+    (Platform.OS === 'ios'
+      ? NativeModules.SettingsManager?.settings.AppleLocale ||
+        NativeModules.SettingsManager?.settings.AppleLanguages[0]
+      : NativeModules.I18nManager?.localeIdentifier) ?? fallbackLocale
+  );
+}
+
+export function currency(amount?: string, currency?: string): string {
+  if (typeof amount === 'undefined' && typeof currency === 'undefined') {
+    return '';
+  }
+
+  const currencyCode = currency ? ` ${currency}` : '';
+
+  try {
+    const locale = getLocale();
+    return (
+      new Intl.NumberFormat(locale.replace(/_/, '-'), {
+        style: 'currency',
+        currency: currency,
+      }).format(Number(amount ?? 0)) + currencyCode
+    );
+  } catch (error) {
+    return `${Number(amount ?? 0).toFixed(2)}` + currencyCode;
+  }
 }


### PR DESCRIPTION
### What are you trying to accomplish?

Adds support for international pricing in the sample app, by sending the country in the queries/mutations. By doing so, the cart will be created with the correct pricing and should not have to switch.

![image](https://github.com/Shopify/checkout-sheet-kit-react-native/assets/2034704/60b83beb-b748-4ea3-94fc-42f2a64f20db)


### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the contributing documentation [readme](/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](/README.md) (if applicable).
