### PR TITLE
[Patch 1.0.2] Maintain viewController to prevent dismissing all modals on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.2 - February 21, 2024
+
+- Improve "close" event logic by only dismissing the Checkout sheet.
+
 ## 1.0.1 - February 20, 2024
 
 - Adds support for view controllers other than the `rootViewController`. This

--- a/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.swift
+++ b/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.swift
@@ -28,13 +28,12 @@ import React
 
 @objc(RCTShopifyCheckoutSheetKit)
 class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
-	private var rootViewController: UIViewController?
+	private var viewControlller: UIViewController?
 
 	private var hasListeners = false
 
 	override init() {
 		super.init()
-		self.rootViewController = UIApplication.shared.delegate?.window??.rootViewController
 	}
 
 	override var methodQueue: DispatchQueue! {
@@ -90,7 +89,8 @@ class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
 			if self.hasListeners {
 				self.sendEvent(withName: "close", body: nil)
 			}
-			self.rootViewController?.dismiss(animated: true)
+			self.viewControlller?.dismiss(animated: true)
+			self.viewControlller = nil
 		}
 	}
 
@@ -128,6 +128,7 @@ class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
 		DispatchQueue.main.async {
 			if let url = URL(string: checkoutURL), let viewController = self.getCurrentViewController() {
 				ShopifyCheckoutSheetKit.present(checkout: url, from: viewController, delegate: self)
+				self.viewControlller = viewController
 			}
 		}
 	}

--- a/modules/@shopify/checkout-sheet-kit/package.json
+++ b/modules/@shopify/checkout-sheet-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-sheet-kit",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "lib/commonjs/index.js",
   "types": "src/index.ts",
   "source": "src/index.ts",


### PR DESCRIPTION
### What changes are you making?

Maintains the `viewController` state so that the `dismiss()` method closes only the Checkout sheet, and not any sheet that triggered the `present`.

<details>
<summary><strong>See before/after</strong></summary>

|Before|After|
|-------|-----|
|![dismiss-before](https://github.com/Shopify/checkout-sheet-kit-react-native/assets/2034704/778ef394-a062-491d-9cf0-1d0736e7a8d9)|![dismiss-after](https://github.com/Shopify/checkout-sheet-kit-react-native/assets/2034704/24eb6ba9-1c2d-4df1-8ff0-a3f658b9648d)|

</details>


---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
> - [ ] I've updated any documentation related to these changes.

---

<details>
<summary>Checklist for releasing a new version</summary>

- [x] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).
- [x] I have added a [Changelog](./CHANGELOG.md) entry.
</details>

> [!TIP] 
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
