### PR TITLE
Fix issue with frozen checkout state on dismiss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.3 - February 21, 2024
+
+- Fixes an issue where the checkout can remain in a frozen empty state after
+  being dismissed.
+
 ## 1.0.2 - February 21, 2024
 
 - Improve "close" event logic by only dismissing the Checkout sheet.

--- a/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.swift
+++ b/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.swift
@@ -84,7 +84,9 @@ class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
 				self.sendEvent(withName: "close", body: nil)
 			}
 
-			self.getCurrentViewController()?.dismiss(animated: true)
+			if let viewController = UIApplication.shared.delegate?.window??.rootViewController {
+				viewController.dismiss(animated: true)
+			}
 		}
 	}
 

--- a/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.swift
+++ b/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.swift
@@ -28,13 +28,7 @@ import React
 
 @objc(RCTShopifyCheckoutSheetKit)
 class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
-	private var viewControlller: UIViewController?
-
 	private var hasListeners = false
-
-	override init() {
-		super.init()
-	}
 
 	override var methodQueue: DispatchQueue! {
 		return DispatchQueue.main
@@ -89,8 +83,8 @@ class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
 			if self.hasListeners {
 				self.sendEvent(withName: "close", body: nil)
 			}
-			self.viewControlller?.dismiss(animated: true)
-			self.viewControlller = nil
+
+			self.getCurrentViewController()?.dismiss(animated: true)
 		}
 	}
 
@@ -128,7 +122,6 @@ class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
 		DispatchQueue.main.async {
 			if let url = URL(string: checkoutURL), let viewController = self.getCurrentViewController() {
 				ShopifyCheckoutSheetKit.present(checkout: url, from: viewController, delegate: self)
-				self.viewControlller = viewController
 			}
 		}
 	}

--- a/modules/@shopify/checkout-sheet-kit/package.json
+++ b/modules/@shopify/checkout-sheet-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-sheet-kit",
   "license": "MIT",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "lib/commonjs/index.js",
   "types": "src/index.ts",
   "source": "src/index.ts",


### PR DESCRIPTION
### What changes are you making?

Fixes an issue where the checkout can remain frozen in an empty state on dismiss

Essentially reverts #69 

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
> - [ ] I've updated any documentation related to these changes.

---

<details>
<summary>Checklist for releasing a new version</summary>

- [x] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).
- [x] I have added a [Changelog](./CHANGELOG.md) entry.
</details>

> [!TIP] 
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
