### PR TITLE
[1.0.4] Dismiss only the checkout sheet on cancel

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,6 @@
 > - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
 > - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
 > - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
-> - [ ] I've updated any documentation related to these changes.
 
 ---
 
@@ -27,5 +26,5 @@
 - [ ] I have added a [Changelog](./CHANGELOG.md) entry.
 </details>
 
-> [!TIP] 
+> [!TIP]
 > See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.4 - March 4, 2024
+
+- Fixes an issue where the parent view controller is dismissed after the
+  checkout sheet is dismissed.
+
 ## 1.0.3 - February 21, 2024
 
 - Fixes an issue where the checkout can remain in a frozen empty state after

--- a/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.swift
+++ b/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.swift
@@ -30,6 +30,8 @@ import React
 class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
 	private var hasListeners = false
 
+	private var checkoutSheet: UIViewController?
+
 	override var methodQueue: DispatchQueue! {
 		return DispatchQueue.main
 	}
@@ -84,9 +86,7 @@ class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
 				self.sendEvent(withName: "close", body: nil)
 			}
 
-			if let viewController = UIApplication.shared.delegate?.window??.rootViewController {
-				viewController.dismiss(animated: true)
-			}
+			self.checkoutSheet?.dismiss(animated: true)
 		}
 	}
 
@@ -123,7 +123,9 @@ class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
 	@objc func present(_ checkoutURL: String) {
 		DispatchQueue.main.async {
 			if let url = URL(string: checkoutURL), let viewController = self.getCurrentViewController() {
-				ShopifyCheckoutSheetKit.present(checkout: url, from: viewController, delegate: self)
+				let view = CheckoutViewController(checkout: url, delegate: self)
+				viewController.present(view, animated: true)
+				self.checkoutSheet = view
 			}
 		}
 	}

--- a/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.swift
+++ b/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.swift
@@ -30,7 +30,7 @@ import React
 class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
 	private var hasListeners = false
 
-	private var checkoutSheet: UIViewController?
+	internal var checkoutSheet: UIViewController?
 
 	override var methodQueue: DispatchQueue! {
 		return DispatchQueue.main

--- a/modules/@shopify/checkout-sheet-kit/package.json
+++ b/modules/@shopify/checkout-sheet-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-sheet-kit",
   "license": "MIT",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "lib/commonjs/index.js",
   "types": "src/index.ts",
   "source": "src/index.ts",

--- a/sample/ios/ReactNativeTests/ShopifyCheckoutSheetKitTests.swift
+++ b/sample/ios/ReactNativeTests/ShopifyCheckoutSheetKitTests.swift
@@ -129,6 +129,7 @@ class ShopifyCheckoutSheetKitTests: XCTestCase {
       }
     }
 
+    mock.checkoutSheet = MockCheckoutSheet()
     mock.startObserving()
     mock.checkoutDidCancel()
 
@@ -136,6 +137,9 @@ class ShopifyCheckoutSheetKitTests: XCTestCase {
     waitForExpectations(timeout: 1, handler: nil)
 
     XCTAssertTrue(mock.didSendEvent)
+
+    // swiftlint:disable:next force_cast
+    XCTAssertTrue((mock.checkoutSheet as! MockCheckoutSheet).dismissWasCalled)
   }
 
   /// checkoutDidFail
@@ -267,5 +271,14 @@ class AsyncRCTShopifyCheckoutSheetKitMock: RCTShopifyCheckoutSheetKit {
 
   override func sendEvent(withName name: String!, body: Any!) {
     sendEventImplementation?(name, body)
+  }
+}
+
+class MockCheckoutSheet: UIViewController {
+  var dismissWasCalled = false
+
+  override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+    dismissWasCalled = true
+    super.dismiss(animated: flag, completion: completion)
   }
 }


### PR DESCRIPTION
### What changes are you making?

Fixes an issue with the SDK dismissing the parent view controller on checkout cancel. Now only the checkout sheet will be dismissed.

---

### PR Checklist

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - ~I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native)~

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.
</details>

> [!TIP] 
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
