### PR TITLE
Implement Universal Links for iOS

### DIFF
--- a/sample/ios/ReactNative/AppDelegate.mm
+++ b/sample/ios/ReactNative/AppDelegate.mm
@@ -2,6 +2,9 @@
 
 #import <React/RCTBundleURLProvider.h>
 
+// Required for deep linking
+#import <React/RCTLinkingManager.h>
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -12,6 +15,14 @@
   self.initialProps = @{};
 
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
+}
+
+// Required for deep linking
+- (BOOL)application:(UIApplication *)application
+   openURL:(NSURL *)url
+   options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+  return [RCTLinkingManager application:application openURL:url options:options];
 }
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge

--- a/sample/ios/ReactNative/Info.plist
+++ b/sample/ios/ReactNative/Info.plist
@@ -34,7 +34,7 @@
 		<true/>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Your location may be required to locate pickup points near you when you request this shipping option.</string>
+	<string>Your location is required to locate pickup points near you.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Entypo.ttf</string>
@@ -53,5 +53,23 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+
+      <!-- This is a custom scheme which will allow you to trigger the app from terminal -->
+      <!-- "xcrun simctl openurl booted rn://cart" -->
+      <key>CFBundleURLSchemes</key>
+			<array>
+				<string>rn</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>rn</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
### What changes are you making?

Implement Universal Links

### How to test

Run the iOS sample app, then execute the following in terminal:

```sh
xcrun simctl openurl booted rn://cart
```

---

Android part:

- https://github.com/Shopify/checkout-sheet-kit-react-native/pull/145