### PR TITLE
Fix CI by unpinning actions/cache version

### DIFF
--- a/.github/actions/install-cocoapods/action.yml
+++ b/.github/actions/install-cocoapods/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Cache cocoapods
       id: cache-cocoapods
-      uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+      uses: actions/cache@v4
       with:
         path: |
           **/ios/Pods

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ runs:
         node-version: 20
 
     - name: Cache turbo build setup
-      uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+      uses: actions/cache@v4
       with:
         path: .turbo
         key: ${{ runner.os }}-turbo-${{ github.sha }}
@@ -19,7 +19,7 @@ runs:
 
     - name: Cache dependencies
       id: yarn-cache
-      uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+      uses: actions/cache@v4
       with:
         path: |
           **/node_modules

--- a/.github/actions/use-turbo-cache/action.yml
+++ b/.github/actions/use-turbo-cache/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Cache turbo build setup
-      uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+      uses: actions/cache@v4
       with:
         path: .turbo
         key: ${{ runner.os }}-turbo-${{ github.sha }}


### PR DESCRIPTION
### What changes are you making?

CI is broken because `actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c`  is outdated (according to Github). Unpinning to see if it fixes it.

From Github:
> _Starting February 1st, 2025, Actions’ cache storage will move to a new architecture, as a result we are closing down v1-v2 of actions/cache. In conjunction, all previous versions of the [@actions/cache package](https://github.com/actions/toolkit/blob/main/packages/cache/README.md) (prior to 4.0.0) in actions/toolkit will be closing down. The action and cache package will be fully retired on March 1st._

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).
- [ ] I have added a [Changelog](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
