### PR TITLE
Fix for automatic colorScheme in the sample

### DIFF
--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 
 import type {PropsWithChildren, ReactNode} from 'react';
 import React, {useEffect, useState} from 'react';
-import {Appearance, Linking, StatusBar} from 'react-native';
+import {Linking, StatusBar} from 'react-native';
 import {
   Link,
   NavigationContainer,
@@ -76,8 +76,6 @@ const config: Configuration = {
     },
   },
 };
-
-Appearance.setColorScheme('light');
 
 export type RootStackParamList = {
   Catalog: undefined;

--- a/sample/src/context/Theme.tsx
+++ b/sample/src/context/Theme.tsx
@@ -170,7 +170,9 @@ export const ThemeProvider: React.FC<
     useState<ColorScheme>(defaultValue);
 
   const setColorScheme = useCallback((colorScheme: ColorScheme) => {
-    if (colorScheme !== ColorScheme.automatic) {
+    if (colorScheme === ColorScheme.automatic) {
+      Appearance.setColorScheme(null);
+    } else {
       Appearance.setColorScheme(
         colorScheme === ColorScheme.dark ? 'dark' : 'light',
       );


### PR DESCRIPTION
### What changes are you making?

Small fix for the automatic colorScheme in the sample

https://github.com/user-attachments/assets/90b89189-0fa1-415e-81ef-c3ee6c8bdb40


https://github.com/user-attachments/assets/bf9279be-6c14-49e1-afa1-62ff057c840c

### How to test

- Switch color scheme to automatic.
- Toggle device dark mode

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).
- [ ] I have added a [Changelog](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
