### PR TITLE
Increase Android CI heap size to 6GB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Run Android tests
         env:
-          GRADLE_OPTS: -Xmx4g
+          GRADLE_OPTS: -Xmx6g
         run: |
           echo "STOREFRONT_DOMAIN=\"myshopify.com\"" > sample/.env
           yarn module build


### PR DESCRIPTION
Following up on https://github.com/Shopify/checkout-sheet-kit-react-native/pull/193, this increases the heap size to 6GB to resolve recurring issues with the CI Pipeline for "Java heap size" errors.

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).
- [ ] I have added a [Changelog](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
