### PR TITLE
Publish package with "next" tag if prerelease version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           # For releases, check the target branch
           if [[ "${{ github.event_name }}" == "release" ]]; then
-            if [[ "${{ github.event.release.target_commitish }}" == "release-candidate" ]]; then
+            if [[ "${{ github.event.release.target_commitish }}" == "next" ]]; then
               echo "tag=next" >> $GITHUB_OUTPUT
             else
               echo "tag=latest" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,15 +20,15 @@ jobs:
       - name: Determine NPM tag
         id: npm-tag
         run: |
-          # For releases, check the target branch
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            if [[ "${{ github.event.release.target_commitish }}" == "next" ]]; then
-              echo "tag=next" >> $GITHUB_OUTPUT
-            else
-              echo "tag=latest" >> $GITHUB_OUTPUT
-            fi
+          # Read the version from package.json
+          VERSION=$(node -p "require('./modules/@shopify/checkout-sheet-kit/package.json').version")
+
+          # Check if it's a "beta" or "rc" version
+          if [[ "$VERSION" == *"-beta"* ]] || [[ "$VERSION" == *"-rc"* ]]; then
+            echo "Version $VERSION is a prerelease, using 'next' tag"
+            echo "tag=next" >> $GITHUB_OUTPUT
           else
-            # For manual workflow dispatch, default to latest
+            echo "Version $VERSION is a stable release, using 'latest' tag"
             echo "tag=latest" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,21 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Determine NPM tag
+        id: npm-tag
+        run: |
+          # For releases, check the target branch
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            if [[ "${{ github.event.release.target_commitish }}" == "release-candidate" ]]; then
+              echo "tag=next" >> $GITHUB_OUTPUT
+            else
+              echo "tag=latest" >> $GITHUB_OUTPUT
+            fi
+          else
+            # For manual workflow dispatch, default to latest
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
+
       - name: Prepare release
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
@@ -24,6 +39,6 @@ jobs:
           yarn module clean
           yarn module build
           cd modules/@shopify/checkout-sheet-kit
-          npm publish --access public
+          npm publish --access public --tag ${{ steps.npm-tag.outputs.tag }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### What changes are you making?

Publishes new release-candidate versions with a `next` tag if the package version contains `-rc` or `-beta`. These versions will be tagged with `@shopify/checkout-sheet-kit@next`

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).
> - [ ] I have added a [Changelog](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/CHANGELOG.md) entry.


> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
