### PR TITLE
Expose AcceleratedCheckoutButtonsProps type

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/src/components/AcceleratedCheckoutButtons.tsx
+++ b/modules/@shopify/checkout-sheet-kit/src/components/AcceleratedCheckoutButtons.tsx
@@ -143,7 +143,7 @@ interface VariantProps {
   quantity: number;
 }
 
-type AcceleratedCheckoutButtonsProps = (CartProps | VariantProps) &
+export type AcceleratedCheckoutButtonsProps = (CartProps | VariantProps) &
   CommonAcceleratedCheckoutButtonsProps;
 
 interface NativeAcceleratedCheckoutButtonsProps {

--- a/modules/@shopify/checkout-sheet-kit/src/index.ts
+++ b/modules/@shopify/checkout-sheet-kit/src/index.ts
@@ -59,7 +59,10 @@ import {CheckoutErrorCode} from './errors.d';
 import type {CheckoutCompletedEvent} from './events.d';
 import type {CustomEvent, PixelEvent, StandardEvent} from './pixels.d';
 import {ApplePayLabel} from './components/AcceleratedCheckoutButtons';
-import type {RenderStateChangeEvent} from './components/AcceleratedCheckoutButtons';
+import type {
+  AcceleratedCheckoutButtonsProps,
+  RenderStateChangeEvent,
+} from './components/AcceleratedCheckoutButtons';
 
 const RNShopifyCheckoutSheetKit = NativeModules.ShopifyCheckoutSheetKit;
 
@@ -477,9 +480,9 @@ export class LifecycleEventParseError extends Error {
 
 // API
 export {
+  AcceleratedCheckoutWallet,
   ApplePayContactField,
   ApplePayLabel,
-  AcceleratedCheckoutWallet,
   ColorScheme,
   ShopifyCheckoutSheet,
   ShopifyCheckoutSheetProvider,
@@ -500,18 +503,19 @@ export {
 
 // Types
 export type {
+  AcceleratedCheckoutButtonsProps,
+  AcceleratedCheckoutConfiguration,
   CheckoutCompletedEvent,
   CheckoutEvent,
   CheckoutEventCallback,
   CheckoutException,
   Configuration,
   CustomEvent,
-  GeolocationRequestEvent,
   Features,
+  GeolocationRequestEvent,
   PixelEvent,
-  StandardEvent,
-  AcceleratedCheckoutConfiguration,
   RenderStateChangeEvent,
+  StandardEvent,
 };
 
 // Components


### PR DESCRIPTION
### What changes are you making?

Exposes the `AcceleratedCheckoutButtonsProps` type so consumers can easily create a wrapper around the component.

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
