### PR TITLE
[Sample] Fix: android won't compile on rn 80

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react": "19.1.0",
     "react-native": "0.80.2",
     "react-native-dotenv": "^3.4.9",
-    "react-native-gesture-handler": "2.25.0",
+    "react-native-gesture-handler": "2.26.0",
     "react-native-gradle-plugin": "^0.71.19",
     "react-test-renderer": "19.1.0",
     "ts-jest": "^29.4.1",

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -2246,7 +2246,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNGestureHandler (2.25.0):
+  - RNGestureHandler (2.26.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2883,7 +2883,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 37cf3321221b0c4f89b0750dbaf466bc99de7a57
   ReactCommon: 592ef441605638b95e533653259254b4bd35ff4f
   RNCMaskedView: 7e0ce15656772a939ff0d269100bca3a182163c8
-  RNGestureHandler: fabb15d507aebf871bf391ec1cdded706c58688b
+  RNGestureHandler: eeb622199ef1fb3a076243131095df1c797072f0
   RNReanimated: 288616f9c66ff4b0911f3862ffcf4104482a2adc
   RNScreens: 26bb60cdb2ef2ca06fd87feefc495072f25982a7
   RNShopifyCheckoutSheetKit: 1c83a5e93cd76358d40a5ecdeaff7075772d35d8

--- a/yarn.lock
+++ b/yarn.lock
@@ -6104,7 +6104,7 @@ __metadata:
     react: "npm:19.1.0"
     react-native: "npm:0.80.2"
     react-native-dotenv: "npm:^3.4.9"
-    react-native-gesture-handler: "npm:2.25.0"
+    react-native-gesture-handler: "npm:2.26.0"
     react-native-gradle-plugin: "npm:^0.71.19"
     react-test-renderer: "npm:19.1.0"
     ts-jest: "npm:^29.4.1"
@@ -11100,9 +11100,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-gesture-handler@npm:2.25.0":
-  version: 2.25.0
-  resolution: "react-native-gesture-handler@npm:2.25.0"
+"react-native-gesture-handler@npm:2.26.0":
+  version: 2.26.0
+  resolution: "react-native-gesture-handler@npm:2.26.0"
   dependencies:
     "@egjs/hammerjs": "npm:^2.0.17"
     hoist-non-react-statics: "npm:^3.3.0"
@@ -11110,7 +11110,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/95eccc67fb07418ef76b84bcee4b29c16865e78afa367ec82d94b08554cfa7337158ab23937b785bd9a732e62c9c815b294a93d1b2c2cbdc7a8a1e7029f2ba35
+  checksum: 10c0/43aee4f0aeb7be9e2e72a9abaeaff38104c188a44ffc1a5634940a851adca5f10ee3a8d1b4828eb654574d4d45aa0f0c2af5a7b4ed2e9bca4e76d0d932f13955
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What changes are you making?
React native gesture handler only added support for react native 80 in 2.26.0
<img width="1065" height="351" alt="image" src="https://github.com/user-attachments/assets/a23c85ce-c1e9-428b-9df5-8d541aaad39f" />




```
> BUILD FAILED in 7m 27s
  error Failed to install the app. Command failed with exit code 1: ./gradlew app:installDebug -PreactNativeDevServerPort=8081
  No modules to process in combine-js-to-schema-cli. If this is unexpected, please check if you set up your NativeComponent correctly.
  See combine-js-to-schema.js for how codegen finds modules.
  Note: Some input files use or override a deprecated API.
  Note: Recompile with -Xlint:deprecation for details.
  Note: Some input files use unchecked or unsafe operations.
  Note: Recompile with -Xlint:unchecked for details.
  Note: Some input files use or override a deprecated API.
  Note: Recompile with -Xlint:deprecation for details.
  /Users/ko/src/github.com/Shopify/checkout-sheet-kit-react-native/modules/@shopify/checkout-sheet-kit/android/src/main/java/com/shopify/
  reactnative/checkoutsheetkit/ShopifyCheckoutSheetKitModule.java:89: warning: [removal] getCurrentActivity() in
  ReactContextBaseJavaModule has been deprecated and marked for removal Activity currentActivity = getCurrentActivity(); ^
  /Users/ko/src/github.com/Shopify/checkout-sheet-kit-react-native/modules/@shopify/checkout-sheet-kit/android/src/main/java/com/shopify/
  reactnative/checkoutsheetkit/ShopifyCheckoutSheetKitModule.java:109: warning: [removal] getCurrentActivity() in
  ReactContextBaseJavaModule hasbeen deprecated and marked for removal Activity currentActivity = getCurrentActivity(); ^
  Note: /Users/ko/src/github.com/Shopify/checkout-sheet-kit-react-native/modules/@shopify/checkout-sheet-kit/android/src/main/java/com/sh
  opify/reactnative/checkoutsheetkit/CustomCheckoutEventProcessor.java uses unchecked or unsafe operations.
  Note: Recompile with -Xlint:unchecked for details.
  2 warnings FAILURE: Build failed with an exception. * What went wrong:
  Execution failed for task ':react-native-gesture-handler:buildCMakeDebug[arm64-v8a]'.
  > com.android.ide.common.process.ProcessException: ninja: Entering directory `/Users/ko/src/github.com/Shopify/checkout-sheet-kit-react
  -native/node_modules/react-native-gesture-handler/android/.cxx/Debug/e151i4xn/arm64-v8a' [1/2] Building CXX object
  CMakeFiles/gesturehandler.dir/cpp-adapter.cpp.o FAILED: CMakeFiles/gesturehandler.dir/cpp-adapter.cpp.o
  /Users/ko/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++
  --target=aarch64-none-linux-android24
  --sysroot=/Users/ko/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -Dgesturehandler_EXPORTS
  -I/Users/ko/src/github.com/Shopify/checkout-sheet-kit-react-native/node_modules/react-native/ReactCommon -isystem /Users/ko/.gradle/cac
  hes/8.14.1/transforms/fbffe0a3b730ede292eba555536301df/transformed/react-android-0.80.2-debug/prefab/modules/reactnative/include
  -isystem /Users/ko/.gradle/caches/8.14.1/transforms/fbffe0a3b730ede292eba555536301df/transformed/react-android-0.80.2-debug/prefab/modu
  les/jsi/include -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes
  -D__BIONIC_NO_PAGE_SIZE_MACRO -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -O2 -frtti -fexceptions -Wall -Werror -std=c++20
  -DANDROID -fno-limit-debug-info -fPIC -DFOLLY_NO_CONFIG=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1
   -DFOLLY_MOBILE=1 -DFOLLY_HAVE_RECVMMSG=1 -DFOLLY_HAVE_PTHREAD=1 -DFOLLY_HAVE_XSI_STRERROR_R=1 -MD -MT
  CMakeFiles/gesturehandler.dir/cpp-adapter.cpp.o -MF CMakeFiles/gesturehandler.dir/cpp-adapter.cpp.o.d -o
  CMakeFiles/gesturehandler.dir/cpp-adapter.cpp.o -c /Users/ko/src/github.com/Shopify/checkout-sheet-kit-react-native/node_modules/react-
  native-gesture-handler/android/src/main/jni/cpp-adapter.cpp In file included from /Users/ko/src/github.com/Shopify/checkout-sheet-kit-r
  eact-native/node_modules/react-native-gesture-handler/android/src/main/jni/cpp-adapter.cpp:4: In file included from /Users/ko/src/githu
  b.com/Shopify/checkout-sheet-kit-react-native/node_modules/react-native/ReactCommon/react/renderer/uimanager/primitives.h:14: In file
  included from /Users/ko/src/github.com/Shopify/checkout-sheet-kit-react-native/node_modules/react-native/ReactCommon/react/renderer/cor
  e/ShadowNode.h:22: /Users/ko/src/github.com/Shopify/checkout-sheet-kit-react-native/node_modules/react-native/ReactCommon/react/rendere
  r/core/State.h:11:10: fatal error: 'fbjni/fbjni.h' file not found 11| #include <fbjni/fbjni.h> | ^~~~~~~~~~~~~~~ 1 error generated.
  ninja: build stopped: subcommand failed. C++ build system [build] failed while executing:
  /Users/ko/Library/Android/sdk/cmake/3.22.1/bin/ninja \ -C \ /Users/ko/src/github.com/Shopify/checkout-sheet-kit-react-native/node_modul
  es/react-native-gesture-handler/android/.cxx/Debug/e151i4xn/arm64-v8a \ gesturehandler from
  /Users/ko/src/github.com/Shopify/checkout-sheet-kit-react-native/node_modules/react-native-gesture-handler/android * Try:
  > Run with --stacktrace option to get the stack trace.
  > Run with --info or --debug option to get more log output.
  > Run with --scan to get full insights.
  > get more help at https://help.gradle.org. build failed in 7m 27s.
  info run cli with --verbose flag for more details.
```

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
