### PR TITLE
fix: remove merge conflict from expo54 fix

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/RNShopifyCheckoutSheetKit.podspec
+++ b/modules/@shopify/checkout-sheet-kit/RNShopifyCheckoutSheetKit.podspec
@@ -42,11 +42,5 @@ Pod::Spec.new do |s|
         "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
         "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
 		}
-
-		s.dependency "React-Codegen"
-		s.dependency "RCT-Folly"
-		s.dependency "RCTRequired"
-		s.dependency "RCTTypeSafety"
-		s.dependency "ReactCommon/turbomodule/core"
   end
 end


### PR DESCRIPTION
### What changes are you making?

There was a bad merge conflict in the latest patch that meant the podspec still had the old dependencies

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
