### PR TITLE
fix dev edition syntax

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,6 +1,6 @@
 name: checkout-sheet-kit-react-native
 
-edition: 2024
+dev.edition: 2024
 
 type: node
 


### PR DESCRIPTION
### What changes are you making?

We were seeing this when running dev up

`This project does not specify dev.edition in dev.yml, so it is using the default value dev.edition 2024.`

I added an `edition` but this was incorrect, it should have been `dev.edition`.

Benefit - quieter logs. No behaviour change expected, as this was the default anyway.

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
