### PR TITLE
Remove outdated liquid reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ experiences.
 - **React Native** - Minimum version `0.70`
 - **iOS** - Minimum version iOS 13
 - **Android** - Minimum Java 11 & Android SDK version `23`
-- **Shopify** - This package is _**not**_ compatible with checkout.liquid. Your
-  Shopify Store must be migrated for extensibility.
 
 ## Getting Started
 

--- a/modules/@shopify/checkout-sheet-kit/src/errors.d.ts
+++ b/modules/@shopify/checkout-sheet-kit/src/errors.d.ts
@@ -23,7 +23,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 
 export enum CheckoutErrorCode {
   storefrontPasswordRequired = 'storefront_password_required',
-  checkoutLiquidNotMigrated = 'checkout_liquid_not_migrated',
   cartExpired = 'cart_expired',
   cartCompleted = 'cart_completed',
   invalidCart = 'invalid_cart',


### PR DESCRIPTION
### What changes are you making?

Removes the error code relating to liquid. Checkout.liquid has been deprecated.

### Notes

1. This should be included in the next stable

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
