### PR TITLE
reduce mocking, remove wildcard imports, and use fluent assertions

### DIFF
--- a/sample/android/app/build.gradle
+++ b/sample/android/app/build.gradle
@@ -117,6 +117,20 @@ android {
       proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
     }
   }
+
+  testOptions {
+    unitTests {
+      all {
+        testLogging {
+          events "failed", "skipped"
+          exceptionFormat "full"
+          showExceptions true
+          showCauses true
+          showStackTraces true
+        }
+      }
+    }
+  }
 }
 
 dependencies {

--- a/sample/android/app/src/test/java/com/shopify/checkoutkitreactnative/ShopifyCheckoutSheetKitModuleTest.java
+++ b/sample/android/app/src/test/java/com/shopify/checkoutkitreactnative/ShopifyCheckoutSheetKitModuleTest.java
@@ -12,6 +12,8 @@ import com.shopify.checkoutsheetkit.ClientException;
 import com.shopify.checkoutsheetkit.ConfigurationException;
 import com.shopify.checkoutsheetkit.HttpException;
 import com.shopify.checkoutsheetkit.ShopifyCheckoutSheetKit;
+import com.shopify.checkoutsheetkit.Preloading;
+import com.shopify.checkoutsheetkit.ColorScheme;
 import com.shopify.checkoutsheetkit.pixelevents.PixelEvent;
 import com.shopify.checkoutsheetkit.pixelevents.StandardPixelEvent;
 import com.shopify.checkoutsheetkit.pixelevents.CustomPixelEvent;
@@ -23,6 +25,7 @@ import com.shopify.checkoutsheetkit.lifecycleevents.Price;
 import com.shopify.reactnative.checkoutsheetkit.ShopifyCheckoutSheetKitModule;
 import com.shopify.reactnative.checkoutsheetkit.CustomCheckoutEventProcessor;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,6 +62,10 @@ public class ShopifyCheckoutSheetKitModuleTest {
 
   private ShopifyCheckoutSheetKitModule shopifyCheckoutSheetKitModule;
 
+  // Store initial configuration to restore after each test
+  private Preloading initialPreloading;
+  private ColorScheme initialColorScheme;
+
   // Test constants for color configuration
   private static final String BACKGROUND_COLOR = "#FFFFFF";
   private static final String PROGRESS_INDICATOR = "#000000";
@@ -77,6 +84,20 @@ public class ShopifyCheckoutSheetKitModuleTest {
     when(mockReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class))
         .thenReturn(mockEventEmitter);
     shopifyCheckoutSheetKitModule = new ShopifyCheckoutSheetKitModule(mockReactContext);
+
+    // Capture initial configuration state to restore after each test
+    initialPreloading = ShopifyCheckoutSheetKitModule.checkoutConfig.getPreloading();
+    initialColorScheme = ShopifyCheckoutSheetKitModule.checkoutConfig.getColorScheme();
+  }
+
+  @After
+  public void tearDown() {
+    // Reset configuration to initial state after each test
+    ShopifyCheckoutSheetKit.configure(configuration -> {
+      configuration.setPreloading(initialPreloading);
+      configuration.setColorScheme(initialColorScheme);
+      ShopifyCheckoutSheetKitModule.checkoutConfig = configuration;
+    });
   }
 
   /**

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -2423,7 +2423,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNScreens (4.15.4):
+  - RNScreens (4.16.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2451,10 +2451,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.15.4)
+    - RNScreens/common (= 4.16.0)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.15.4):
+  - RNScreens/common (4.16.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2881,7 +2881,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 7e0ce15656772a939ff0d269100bca3a182163c8
   RNGestureHandler: eeb622199ef1fb3a076243131095df1c797072f0
   RNReanimated: 288616f9c66ff4b0911f3862ffcf4104482a2adc
-  RNScreens: 26bb60cdb2ef2ca06fd87feefc495072f25982a7
+  RNScreens: 3fc29af06302e1f1c18a7829fe57cbc2c0259912
   RNShopifyCheckoutSheetKit: c6c08fbeaf22de14c5d1d0a745329e96b0722f79
   RNVectorIcons: be4d047a76ad307ffe54732208fb0498fcb8477f
   ShopifyCheckoutSheetKit: 2251f2708752ad0b8a7f7baf1ee527d2167b0d4b

--- a/sample/package.json
+++ b/sample/package.json
@@ -28,8 +28,8 @@
     "react-native-config": "1.5.6",
     "react-native-dotenv": "^3.4.11",
     "react-native-reanimated": "3.18.0",
-    "react-native-safe-area-context": "^5.2.0",
-    "react-native-screens": "^4.10.0",
+    "react-native-safe-area-context": "^5.6.1",
+    "react-native-screens": "^4.16.0",
     "react-native-vector-icons": "^10.3.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11185,7 +11185,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-safe-area-context@npm:^5.2.0":
+"react-native-safe-area-context@npm:^5.6.1":
   version: 5.6.1
   resolution: "react-native-safe-area-context@npm:5.6.1"
   peerDependencies:
@@ -11195,9 +11195,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:^4.10.0":
-  version: 4.15.4
-  resolution: "react-native-screens@npm:4.15.4"
+"react-native-screens@npm:^4.16.0":
+  version: 4.16.0
+  resolution: "react-native-screens@npm:4.16.0"
   dependencies:
     react-freeze: "npm:^1.0.0"
     react-native-is-edge-to-edge: "npm:^1.2.1"
@@ -11205,7 +11205,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/0e0e998688742741f323a332e9a2c502f10e9e73c21cd9a25457dd71f24a1bec5091141385d5fb25cf86f78c9f1799e145f0a9a4c6af5ffd97ecf7e9a53acd95
+  checksum: 10c0/8ec459ff52cbd317bfca598843a0010b4ca9070d05664f28d792594d8ceabb398b9d68abb578f40295e41f906308efe7ac7359046fba7aaf318a0d9d65446102
   languageName: node
   linkType: hard
 
@@ -11729,8 +11729,8 @@ __metadata:
     react-native-config: "npm:1.5.6"
     react-native-dotenv: "npm:^3.4.11"
     react-native-reanimated: "npm:3.18.0"
-    react-native-safe-area-context: "npm:^5.2.0"
-    react-native-screens: "npm:^4.10.0"
+    react-native-safe-area-context: "npm:^5.6.1"
+    react-native-screens: "npm:^4.16.0"
     react-native-vector-icons: "npm:^10.3.0"
     setimmediate: "npm:^1.0.5"
   peerDependencies:


### PR DESCRIPTION
### What changes are you making?

A few tweaks to the android tests:

- update build.gradle to configure better test output
- use assertj fluent assertions
- reduce mocking
- removed wildcard imports (just a preference to reduce the cluttering of the local namespace)
- stronger assertions in places - (e.g. check we default colorScheme to `automatic` rather than checking `isNotNull()`
- switch to behavioural test names (probably also just a preference)
- adds a few new tests, things like moduleName, disabling preloading.

Note the build was failing to resolve react-native-safe-area-context and react-native-screens. Bumping to latest resolve that.

### PR Checklist

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
