### PR TITLE
Udpdate CONTRIBUTING.md with additional step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,33 +16,39 @@ specific to each workspace.
 
 ## Getting started
 
-If you've cloned the repo and want to run the sample app, you will first need
-to:
+If you've cloned the repo and want to run the sample app, you will first need to:
 
 1. Install the NPM dependencies
-2. Install iOS dependencies (cocoapods)
+
+   ```sh
+   yarn
+   ```
+
+2. Install iOS dependencies. (N.b. Android dependencies are automatically installed by Gradle)
+
+   ```sh
+   yarn pod-install sample/ios
+   ```
+
 3. Build the Native Module
 
-```sh
-# Install NPM dependencies and link local module
-yarn
+   ```sh
+   yarn module build
+   ```
 
-# Install Cocoapods for iOS
-yarn pod-install sample/ios
-# Note: Android dependencies are automatically installed by Gradle
+4. Start the Metro server
 
-# Build the Native Module JS
-yarn module build
-```
+   ```sh
+   yarn sample start
+   ```
 
-If all of these steps have succeeded, you can now run the sample app with:
+5. Run the sample application (in a new terminal / tab)
 
-```sh
-yarn sample start
-```
-
-This command will start the Metro server. Follow the steps given by Metro to
-open both the iOS and Android simulators/emulators respectively.
+   ```sh
+   yarn sample ios
+   # or
+   yarn sample android
+   ```
 
 ## Optional: Speed up builds with ccache
 


### PR DESCRIPTION
### What changes are you making?

Updates contributing with the additional step to run `yarn sample ios` / `yarn sample android`, now that we no longer launch them from the metro server terminal.

<img width="503" height="689" alt="Screenshot 2025-11-04 at 09 36 54" src="https://github.com/user-attachments/assets/25bd9573-6ea3-4ce5-821f-aba5244f3acd" />

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
