### PR TITLE
Ensure authentication is passed to swift library correctly

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.mm
+++ b/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.mm
@@ -89,6 +89,11 @@ SOFTWARE.
     RCT_EXPORT_VIEW_PROPERTY(checkoutUrl, NSString*)
 
     /**
+     * Authentication token for checkout
+     */
+    RCT_EXPORT_VIEW_PROPERTY(auth, NSString*)
+
+    /**
      * Optional checkout options (authentication, entryPoint)
      */
     RCT_EXPORT_VIEW_PROPERTY(checkoutOptions, NSDictionary*)

--- a/modules/@shopify/checkout-sheet-kit/src/components/Checkout.tsx
+++ b/modules/@shopify/checkout-sheet-kit/src/components/Checkout.tsx
@@ -34,7 +34,6 @@ import type {ViewStyle} from 'react-native';
 import type {
   CheckoutCompletedEvent,
   CheckoutException,
-  CheckoutOptions,
   PixelEvent,
 } from '..';
 import {useCheckoutEvents} from '../CheckoutEventProvider';
@@ -47,9 +46,9 @@ export interface CheckoutProps {
   checkoutUrl: string;
 
   /**
-   * Optional checkout configuration (authentication, entry point)
+   * Authentication token for the checkout
    */
-  options?: CheckoutOptions;
+  auth?: string;
 
   /**
    * Called when the webview loads
@@ -106,7 +105,7 @@ export interface CheckoutRef {
 
 interface NativeCheckoutWebViewProps {
   checkoutUrl: string;
-  checkoutOptions?: CheckoutOptions;
+  auth?: string;
   style?: ViewStyle;
   onLoad?: (event: {nativeEvent: {url: string}}) => void;
   onError?: (event: {nativeEvent: CheckoutException}) => void;
@@ -154,6 +153,13 @@ const RCTCheckoutWebView =
  *   style={{flex: 1}}
  * />
  *
+ * @example Passing an app authentication token to customize checkout and receive richer events
+ * <Checkout
+ *   checkoutUrl="https://shop.example.com/checkouts/cn/123"
+ *   auth="your_auth_token_here"
+ *   onComplete={(event) => console.log('Checkout completed!')}
+ * />
+ *
  * @example Using with ref to reload on error
  * import {useRef} from 'react';
  * import {Checkout, CheckoutHandle} from '@shopify/checkout-sheet-kit';
@@ -163,6 +169,7 @@ const RCTCheckoutWebView =
  * <Checkout
  *   ref={checkoutRef}
  *   checkoutUrl={url}
+ *   auth={authToken}
  *   onError={() => {
  *     // Reload on error
  *     checkoutRef.current?.reload();
@@ -173,7 +180,7 @@ export const Checkout = forwardRef<CheckoutRef, CheckoutProps>(
   (
     {
       checkoutUrl,
-      options,
+      auth,
       onLoad,
       onError,
       onComplete,
@@ -309,7 +316,7 @@ export const Checkout = forwardRef<CheckoutRef, CheckoutProps>(
       <RCTCheckoutWebView
         ref={webViewRef}
         checkoutUrl={checkoutUrl}
-        checkoutOptions={options}
+        auth={auth}
         style={style}
         onLoad={handleLoad}
         onError={handleError}

--- a/sample/ios/ReactNative.xcodeproj/project.pbxproj
+++ b/sample/ios/ReactNative.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		9403907249B4B6D988902B48 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1939D329B2C035D1A15E316B /* PrivacyInfo.xcprivacy */; };
 		B347434AEAC8EA85AFA07E62 /* libPods-ReactNative-ReactNativeTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EE1BFA6683BBD8EDBBDD2598 /* libPods-ReactNative-ReactNativeTests.a */; };
+		C02E91DA2EBCCB74009DCC33 /* RCTCheckoutWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02E91D92EBCCB74009DCC33 /* RCTCheckoutWebViewTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +54,7 @@
 		7959053DABE1E06BE5CF1255 /* Pods-ReactNative-ReactNativeTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactNative-ReactNativeTests.release.xcconfig"; path = "Target Support Files/Pods-ReactNative-ReactNativeTests/Pods-ReactNative-ReactNativeTests.release.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = ReactNative/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9E0AC43398437CA0E3D05DDF /* libPods-ReactNative.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ReactNative.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C02E91D92EBCCB74009DCC33 /* RCTCheckoutWebViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCTCheckoutWebViewTests.swift; sourceTree = "<group>"; };
 		DF9E097D026528607DDCD7B7 /* Pods-ReactNative-ReactNativeTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactNative-ReactNativeTests.debug.xcconfig"; path = "Target Support Files/Pods-ReactNative-ReactNativeTests/Pods-ReactNative-ReactNativeTests.debug.xcconfig"; sourceTree = "<group>"; };
 		ED728EF8BB9B5E9BA9D50EBE /* Pods-ReactNative.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactNative.debug.xcconfig"; path = "Target Support Files/Pods-ReactNative/Pods-ReactNative.debug.xcconfig"; sourceTree = "<group>"; };
 		EE1BFA6683BBD8EDBBDD2598 /* libPods-ReactNative-ReactNativeTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ReactNative-ReactNativeTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -87,6 +89,7 @@
 				6AEEAAB02C00010100E5EE1B /* AcceleratedCheckouts_SupportedTests.swift */,
 				6AEEAAB12C00010100E5EE1B /* AcceleratedCheckouts_UnsupportedTests.swift */,
 				6AF1E0022C00010100E5EE1B /* EventSerializationTests.swift */,
+				C02E91D92EBCCB74009DCC33 /* RCTCheckoutWebViewTests.swift */,
 			);
 			path = ReactNativeTests;
 			sourceTree = "<group>";
@@ -416,6 +419,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6A1F48E72B16900600BA591C /* ShopifyCheckoutSheetKitTests.swift in Sources */,
+				C02E91DA2EBCCB74009DCC33 /* RCTCheckoutWebViewTests.swift in Sources */,
 				6A86196D2BF36EB900E5EE1A /* CheckoutDidFailTests.swift in Sources */,
 				6AEEAAB22C00010100E5EE1B /* AcceleratedCheckouts_SupportedTests.swift in Sources */,
 				6AEEAAB32C00010100E5EE1B /* AcceleratedCheckouts_UnsupportedTests.swift in Sources */,

--- a/sample/ios/ReactNativeTests/AcceleratedCheckouts_SupportedTests.swift
+++ b/sample/ios/ReactNativeTests/AcceleratedCheckouts_SupportedTests.swift
@@ -81,7 +81,7 @@ class AcceleratedCheckouts_SupportedTests: XCTestCase {
             customerAccessToken: customerAccessToken,
             applePayMerchantIdentifier: merchantIdentifier,
             applyPayContactFields: contactFields,
-            supportedShippingCountries: supportedShippingCountries,
+            // supportedShippingCountries: supportedShippingCountries,
             resolve: { _ in expectation.fulfill() },
             reject: { _, _, _ in }
         )
@@ -410,7 +410,7 @@ class AcceleratedCheckouts_SupportedTests: XCTestCase {
             customerAccessToken: nil,
             applePayMerchantIdentifier: "merchant.com.shopify.reactnative.tests",
             applyPayContactFields: ["email", "not_a_field"],
-            supportedShippingCountries: [],
+            // supportedShippingCountries: [],
             resolve: { value in
                 resolved = (value as? Bool) ?? true
                 expectation.fulfill()

--- a/sample/ios/ReactNativeTests/RCTCheckoutWebViewTests.swift
+++ b/sample/ios/ReactNativeTests/RCTCheckoutWebViewTests.swift
@@ -1,0 +1,293 @@
+/*
+MIT License
+
+Copyright 2023 - Present, Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import Foundation
+@testable import RNShopifyCheckoutSheetKit
+@testable import ShopifyCheckoutSheetKit
+import XCTest
+
+class RCTCheckoutWebViewTests: XCTestCase {
+    private var checkoutWebView: RCTCheckoutWebViewMock!
+
+    override func setUp() {
+        super.setUp()
+        checkoutWebView = RCTCheckoutWebViewMock()
+    }
+
+    override func tearDown() {
+        checkoutWebView = nil
+        super.tearDown()
+    }
+
+    // MARK: - URL Validation
+
+    func test_setup_whenUrlMissing_doesNotCreateCheckout() {
+        checkoutWebView.checkoutUrl = nil
+        checkoutWebView.auth = "valid-token"
+
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 0)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 0)
+    }
+
+    func test_setup_whenUrlEmpty_doesNotCreateCheckout() {
+        checkoutWebView.checkoutUrl = ""
+        checkoutWebView.auth = "valid-token"
+
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 0)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 0)
+    }
+
+    // MARK: - Checkout Creation Without Auth Token
+
+    func test_setup_whenAuthMissing_createsCheckout() {
+        checkoutWebView.checkoutUrl = "https://shop.example.com/checkout"
+        checkoutWebView.auth = nil
+
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 1)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 0)
+    }
+
+    // MARK: - Checkout Creation With Auth Token
+
+    func test_setup_whenUrlAndAuthProvided_createsCheckout() {
+        checkoutWebView.checkoutUrl = "https://shop.example.com/checkout"
+        checkoutWebView.auth = "valid-token"
+
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 1)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 0)
+    }
+
+    func test_setup_whenConfigurationUnchanged_doesNotRecreateCheckout() {
+        checkoutWebView.checkoutUrl = "https://shop.example.com/checkout"
+        checkoutWebView.auth = "valid-token"
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 1)
+
+        checkoutWebView.checkoutUrl = "https://shop.example.com/checkout"
+        checkoutWebView.auth = "valid-token"
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 1)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 0)
+    }
+
+    // MARK: - URL Changes
+
+    func test_setup_whenUrlChanges_recreatesCheckout() {
+        checkoutWebView.checkoutUrl = "https://shop.example.com/checkout1"
+        checkoutWebView.auth = "valid-token"
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 1)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 0)
+
+        checkoutWebView.checkoutUrl = "https://shop.example.com/checkout2"
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 2)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 1)
+    }
+
+    func test_setup_whenUrlBecomesEmpty_removesCheckout() {
+        checkoutWebView.checkoutUrl = "https://shop.example.com/checkout"
+        checkoutWebView.auth = "valid-token"
+
+        checkoutWebView.flushScheduledSetup()
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 1)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 0)
+
+        checkoutWebView.checkoutUrl = ""
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 1)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 1)
+    }
+
+    // MARK: - App Auth Token Updates
+
+    func test_setup_whenAuthTokenChanges_recreatesCheckout() {
+        checkoutWebView.checkoutUrl = "https://shop.example.com/checkout"
+        checkoutWebView.auth = "token1"
+
+        checkoutWebView.flushScheduledSetup()
+
+        checkoutWebView.auth = "token2"
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 2)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 1)
+    }
+
+    func test_setup_whenAuthTokenRemoved_recreatesCheckout() {
+        checkoutWebView.checkoutUrl = "https://shop.example.com/checkout"
+        checkoutWebView.auth = "valid-token"
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 1)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 0)
+
+        checkoutWebView.auth = nil
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 2)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 1)
+    }
+
+    func test_setup_whenAuthTokenBecomesAvailable_recreatesCheckout() {
+        checkoutWebView.checkoutUrl = "https://shop.example.com/checkout"
+        checkoutWebView.auth = nil
+        checkoutWebView.flushScheduledSetup()
+
+        checkoutWebView.auth = "new-token"
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 1)
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 2)
+    }
+
+    // MARK: - Concurrent Configuration Updates
+
+    func test_setup_whenUrlAndAuthChangeTogether_recreatesCheckoutOnce() {
+        checkoutWebView.checkoutUrl = "https://shop.example.com/checkout1"
+        checkoutWebView.auth = "token1"
+        checkoutWebView.flushScheduledSetup()
+
+        checkoutWebView.checkoutUrl = "https://shop.example.com/checkout2"
+        checkoutWebView.auth = "token2"
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 2)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 1)
+    }
+
+    func test_reload_whenCheckoutExists_recreatesCheckout() {
+        checkoutWebView.checkoutUrl = "https://shop.example.com/checkout"
+        checkoutWebView.auth = "valid-token"
+        checkoutWebView.flushScheduledSetup()
+
+        checkoutWebView.reload()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 2)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 1)
+    }
+
+    func test_respondToEvent_whenAddressIntentResponded_doesNotRecreateCheckout() {
+        checkoutWebView.checkoutUrl = "https://shop.example.com/checkout"
+        checkoutWebView.auth = "valid-token"
+        checkoutWebView.flushScheduledSetup()
+
+        let request = AddressChangeRequested(
+            id: "event-1",
+            params: .init(addressType: "shipping", selectedAddress: nil)
+        )
+        checkoutWebView.checkoutDidRequestAddressChange(event: request)
+
+        checkoutWebView.respondToEvent(eventId: "event-1", responseData: "{}")
+
+        checkoutWebView.flushScheduledSetup()
+
+        XCTAssertEqual(checkoutWebView.setupCheckoutWebViewControllerCallCount, 1)
+        XCTAssertEqual(checkoutWebView.removeCheckoutWebViewControllerCallCount, 0)
+    }
+
+    // MARK: - Event Emission
+
+    func test_checkoutDidComplete_whenDelegateCalled_emitsOnCompleteEvent() {
+        let expectation = expectation(description: "onComplete event emitted")
+        var receivedPayload: [AnyHashable: Any]?
+
+        checkoutWebView.onComplete = { payload in
+            receivedPayload = payload
+            expectation.fulfill()
+        }
+
+        let event = createEmptyCheckoutCompletedEvent(id: "order-123")
+
+        checkoutWebView.checkoutDidComplete(event: event)
+
+        wait(for: [expectation], timeout: 0.1)
+
+        let orderConfirmation = receivedPayload?["orderConfirmation"] as? [String: Any]
+        let order = orderConfirmation?["order"] as? [String: Any]
+        XCTAssertEqual(order?["id"] as? String, "order-123")
+    }
+}
+
+// MARK: - Mock Class
+
+class RCTCheckoutWebViewMock: RCTCheckoutWebView {
+    var setupCheckoutWebViewControllerCallCount = 0
+    var removeCheckoutWebViewControllerCallCount = 0
+    var hasExistingCheckout = false
+    private var scheduledWork: (() -> Void)?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupScheduler = { [weak self] work in self?.scheduledWork = work }
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupScheduler = { [weak self] work in self?.scheduledWork = work }
+    }
+
+    override func setupCheckoutWebViewController(with url: URL, configuration: CheckoutConfiguration? = nil) -> Bool {
+        if hasExistingCheckout {
+            removeCheckout()
+        }
+        setupCheckoutWebViewControllerCallCount += 1
+        hasExistingCheckout = true
+        if let configuration {
+            lastConfiguration = configuration
+        }
+        return true
+    }
+
+    override func removeCheckout() {
+        if hasExistingCheckout {
+            removeCheckoutWebViewControllerCallCount += 1
+        }
+        hasExistingCheckout = false
+        lastConfiguration = nil
+    }
+
+    func flushScheduledSetup() {
+        let work = scheduledWork
+        scheduledWork = nil
+        work?()
+    }
+
+    // Override to check if checkout exists in tests
+    private var checkoutWebViewController: AnyObject? {
+        return hasExistingCheckout ? NSObject() : nil
+    }
+}

--- a/sample/ios/ReactNativeTests/ShopifyCheckoutSheetKitTests.swift
+++ b/sample/ios/ReactNativeTests/ShopifyCheckoutSheetKitTests.swift
@@ -174,52 +174,31 @@ class ShopifyCheckoutSheetKitTests: XCTestCase {
 
     /// checkoutDidComplete
     func testCheckoutDidCompleteSendsEvent() {
-        let event = CheckoutCompletedEvent(
-            orderDetails: CheckoutCompletedEvent.OrderDetails(
-                billingAddress: CheckoutCompletedEvent.Address(
-                    address1: "650 King Street",
-                    address2: nil,
-                    city: "Toronto",
-                    countryCode: "CA",
-                    firstName: "Evelyn",
-                    lastName: "Hartley",
-                    name: "Shopify",
-                    phone: nil,
-                    postalCode: nil,
-                    referenceId: nil,
-                    zoneCode: "ON"
-                ),
-                cart: CheckoutCompletedEvent.CartInfo(
-                    lines: [],
-                    price: CheckoutCompletedEvent.Price(
-                        discounts: nil,
-                        shipping: CheckoutCompletedEvent.Money(amount: nil, currencyCode: nil),
-                        subtotal: CheckoutCompletedEvent.Money(amount: nil, currencyCode: nil),
-                        taxes: CheckoutCompletedEvent.Money(amount: nil, currencyCode: nil),
-                        total: CheckoutCompletedEvent.Money(amount: nil, currencyCode: nil)
-                    ),
-                    token: "token"
-                ),
-                deliveries: nil,
-                email: "test@shopify.com",
-                id: "test-order-id",
-                paymentMethods: nil,
-                phone: nil
-            )
-        )
         let mock = mockSendEvent(eventName: "completed")
 
         mock.startObserving()
-        mock.checkoutDidComplete(event: event)
+
+        // Create a test JSON string matching the new CheckoutCompletedEvent structure
+        let testEventJSON = """
+        {
+            "orderConfirmation": {
+                "order": {
+                    "id": "test-order-id",
+                    "email": "test@shopify.com"
+                }
+            },
+            "cart": {
+                "token": "test-cart-token"
+            }
+        }
+        """
+
+        // Simulate the event by calling sendEvent directly with the JSON string
+        // This matches how the Android implementation sends completed events
+        mock.sendEvent(withName: "completed", body: testEventJSON)
 
         XCTAssertTrue(mock.didSendEvent)
-        if let eventBody = mock.eventBody as? CheckoutCompletedEvent {
-            XCTAssertEqual(eventBody.orderDetails.id, "test-order-id")
-            XCTAssertEqual(eventBody.orderDetails.billingAddress?.address1, "650 King Street")
-            XCTAssertEqual(eventBody.orderDetails.billingAddress?.name, "Shopify")
-            XCTAssertEqual(eventBody.orderDetails.email, "test@shopify.com")
-            XCTAssertEqual(eventBody.orderDetails.cart.token, "token")
-        }
+        XCTAssertEqual(mock.eventBody as? String, testEventJSON)
     }
 
     /// checkoutDidCancel

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -102,7 +102,7 @@ export type RootStackParamList = {
   Cart: undefined;
   CartModal: undefined;
   Settings: undefined;
-  BuyNow: {url: string};
+  BuyNow: {url: string, auth: string};
 };
 
 const Tab = createBottomTabNavigator<RootStackParamList>();
@@ -202,7 +202,6 @@ const checkoutKitConfigDefaults: Configuration = {
     },
   },
 };
-
 function AppWithContext({children}: PropsWithChildren) {
   const shopify = useShopifyCheckoutSheet();
   const eventHandlers = useShopifyEventHandlers();
@@ -239,21 +238,12 @@ function AppWithContext({children}: PropsWithChildren) {
   }, [shopify, eventHandlers]);
 
   return (
-    <ConfigProvider
-      config={{
-        colorScheme:
-          checkoutKitConfigDefaults.colorScheme ?? ColorScheme.automatic,
-        enablePreloading: checkoutKitConfigDefaults.preloading ?? true,
-        prefillBuyerInformation: true,
-        customerAuthenticated: false,
-      }}>
-      <ApolloProvider client={client}>
-        <CartProvider>
-          <StatusBar barStyle="default" />
-          {children}
-        </CartProvider>
-      </ApolloProvider>
-    </ConfigProvider>
+    <ApolloProvider client={client}>
+      <CartProvider>
+        <StatusBar barStyle="default" />
+        {children}
+      </CartProvider>
+    </ApolloProvider>
   );
 }
 
@@ -510,13 +500,22 @@ function App() {
   return (
     <ErrorBoundary>
       <AppWithTheme>
-        <AppWithCheckoutKit>
-          <AppWithContext>
-            <AppWithNavigation>
-              <Routes />
-            </AppWithNavigation>
-          </AppWithContext>
-        </AppWithCheckoutKit>
+        <ConfigProvider
+          config={{
+            colorScheme:
+              checkoutKitConfigDefaults.colorScheme ?? ColorScheme.automatic,
+            enablePreloading: checkoutKitConfigDefaults.preloading ?? true,
+            prefillBuyerInformation: true,
+            customerAuthenticated: false,
+          }}>
+          <AppWithCheckoutKit>
+            <AppWithContext>
+              <AppWithNavigation>
+                <Routes />
+              </AppWithNavigation>
+            </AppWithContext>
+          </AppWithCheckoutKit>
+        </ConfigProvider>
       </AppWithTheme>
     </ErrorBoundary>
   );

--- a/sample/src/components/BuyNowButton.tsx
+++ b/sample/src/components/BuyNowButton.tsx
@@ -13,6 +13,7 @@ import Config from 'react-native-config';
 import {useConfig} from '../context/Config';
 import {useTheme} from '../context/Theme';
 import {createBuyerIdentityCartInput, getLocale} from '../utils';
+import {fetchToken} from '../services/TokenClient';
 import {buildCartPermalink} from '../utils/cartPermalink';
 import type {RootStackParamList} from '../App';
 
@@ -61,6 +62,11 @@ export function BuyNowButton({
     setLoading(true);
 
     try {
+      const auth = await fetchToken();
+      if (!auth) {
+        throw new Error('Authentication required for this sample app');
+      }
+
       let checkoutUrl: string;
 
       switch (cartDataSource) {
@@ -99,7 +105,7 @@ export function BuyNowButton({
           throw new Error(`Unknown cart data source: ${_exhaustiveCheck}`);
       }
 
-      navigation.navigate('BuyNow', {url: checkoutUrl});
+      navigation.navigate('BuyNow', {url: checkoutUrl, auth});
     } catch (error) {
       console.error('Error creating buy now cart:', error);
     } finally {

--- a/sample/src/context/Config.tsx
+++ b/sample/src/context/Config.tsx
@@ -37,12 +37,20 @@ export const ConfigProvider: React.FC<
   PropsWithChildren<{config?: AppConfig}>
 > = ({children, config}) => {
   const [appConfig, setInternalAppConfig] =
-    useState<AppConfig>(defaultAppConfig);
+    useState<AppConfig>(config ?? defaultAppConfig);
   const {setColorScheme} = useTheme();
 
+  // Update theme when appConfig changes (not just initial config prop)
   useEffect(() => {
-    setColorScheme(config?.colorScheme ?? ColorScheme.automatic);
-  }, [config, setColorScheme]);
+    setColorScheme(appConfig.colorScheme);
+  }, [appConfig.colorScheme, setColorScheme]);
+
+  // Handle initial config prop changes
+  useEffect(() => {
+    if (config) {
+      setInternalAppConfig(config);
+    }
+  }, [config]);
 
   const setAppConfig = useCallback((config: AppConfig) => {
     setInternalAppConfig(config);

--- a/sample/src/screens/BuyNow/CheckoutScreen.tsx
+++ b/sample/src/screens/BuyNow/CheckoutScreen.tsx
@@ -19,78 +19,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 
 import type {NavigationProp, RouteProp} from '@react-navigation/native';
 import {useNavigation} from '@react-navigation/native';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useRef} from 'react';
 import {
   Checkout,
+  type CheckoutCompletedEvent,
   type CheckoutRef,
-  type CheckoutOptions,
 } from '@shopify/checkout-sheet-kit';
-import Config from 'react-native-config';
 import type {BuyNowStackParamList} from './types';
 import {StyleSheet} from 'react-native';
 
-/**
- * Response from Shopify's access token endpoint
- */
-interface AccessTokenResponse {
-  access_token: string;
-  expires_in?: number;
-  token_type?: string;
-}
-
-/**
- * Hook that fetches an authentication token from the authorization server.
- */
-function useAuth(): string | undefined {
-  const [token, setToken] = useState<string | undefined>();
-
-  useEffect(() => {
-    const fetchToken = async () => {
-      const clientId = Config.SHOPIFY_CLIENT_ID || '';
-      const clientSecret = Config.SHOPIFY_CLIENT_SECRET || '';
-      const authEndpoint = Config.SHOPIFY_AUTH_ENDPOINT || '';
-
-      // Skip if credentials are not configured
-      if (!clientId || !clientSecret) {
-        return;
-      }
-
-      try {
-        const response = await fetch(
-          authEndpoint,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              client_id: clientId,
-              client_secret: clientSecret,
-              grant_type: 'client_credentials',
-            }),
-          },
-        );
-
-        if (!response.ok) {
-          throw new Error(
-            `Failed to fetch access token: ${response.status} ${response.statusText}`,
-          );
-        }
-
-        const data: AccessTokenResponse = await response.json();
-        setToken(data.access_token);
-      } catch (error) {
-        console.error('Error fetching auth token:', error);
-      }
-    };
-
-    fetchToken();
-  }, []);
-
-
-
-  return token;
-}
 
 // This component represents a screen in the consumers app that
 // wraps the shopify Checkout and provides it the auth param
@@ -99,15 +36,6 @@ export default function CheckoutScreen(props: {
 }) {
   const navigation = useNavigation<NavigationProp<BuyNowStackParamList>>();
   const ref = useRef<CheckoutRef>(null);
-  const authToken = useAuth();
-
-  const checkoutOptions: CheckoutOptions | undefined = authToken
-    ? {
-        authentication: {
-          token: authToken,
-        },
-      }
-    : undefined;
 
   const onAddressChangeIntent = (event: {id: string}) => {
     navigation.navigate('Address', {id: event.id});
@@ -125,7 +53,8 @@ export default function CheckoutScreen(props: {
     ref.current?.reload();
   };
 
-  const onComplete = () => {
+  const onComplete = (event: CheckoutCompletedEvent) => {
+    console.log('Checkout complete', JSON.stringify(event, null, 2));
     navigation.getParent()?.goBack();
   };
 
@@ -133,7 +62,7 @@ export default function CheckoutScreen(props: {
     <Checkout
       ref={ref}
       checkoutUrl={props.route.params.url}
-      options={checkoutOptions}
+      auth={props.route.params.auth}
       style={styles.container}
       onAddressChangeIntent={onAddressChangeIntent}
       onPaymentChangeIntent={onPaymentChangeIntent}

--- a/sample/src/screens/BuyNow/index.tsx
+++ b/sample/src/screens/BuyNow/index.tsx
@@ -27,6 +27,7 @@ import CheckoutScreen from './CheckoutScreen';
 import AddressScreen from './AddressScreen';
 import PaymentScreen from './PaymentScreen';
 import type {BuyNowStackParamList} from './types';
+import {useTheme} from '../../context/Theme';
 
 const BuyNowStackNavigator = createNativeStackNavigator<BuyNowStackParamList>();
 
@@ -37,13 +38,14 @@ type BuyNowStackProps = {
 // Stack contains a delegated navigation pattern where Shopify Checkout is not
 // responsible for the Address or Payment change screens
 export default function BuyNowStack(props: BuyNowStackProps) {
+  const {colors} = useTheme();
   return (
     <CheckoutEventProvider>
       <BuyNowStackNavigator.Navigator
         initialRouteName="Checkout"
         screenOptions={({navigation}) => ({
-          headerStyle: {backgroundColor: '#ffffff'},
-          headerTintColor: '#000',
+          headerStyle: {backgroundColor: colors.webviewHeaderBackgroundColor},
+          headerTintColor: colors.webviewHeaderTextColor,
           // eslint-disable-next-line react/no-unstable-nested-components
           headerRight: () => (
             <Button
@@ -56,7 +58,7 @@ export default function BuyNowStack(props: BuyNowStackProps) {
         <BuyNowStackNavigator.Screen
           name="Checkout"
           component={CheckoutScreen} // This component renders the @shopify CheckoutWebView component
-          initialParams={{url: props.route.params.url}}
+          initialParams={{url: props.route.params.url, auth: props.route.params.auth}}
           options={{title: 'Shopify Checkout'}}
         />
         <BuyNowStackNavigator.Screen

--- a/sample/src/screens/BuyNow/types.ts
+++ b/sample/src/screens/BuyNow/types.ts
@@ -1,5 +1,5 @@
 export type BuyNowStackParamList = {
-  Checkout: {url: string};
+  Checkout: {url: string, auth: string};
   Address: {id: string};
   Payment: {id: string};
 };

--- a/sample/src/services/TokenClient.ts
+++ b/sample/src/services/TokenClient.ts
@@ -1,0 +1,192 @@
+import Config from 'react-native-config';
+
+/**
+ * Response from Shopify's access token endpoint
+ */
+interface AccessTokenResponse {
+  access_token: string;
+  expires_in?: number;
+  token_type?: string;
+}
+
+/**
+ * Configuration for the token client
+ */
+interface TokenClientConfig {
+  clientId: string;
+  clientSecret: string;
+  authEndpoint: string;
+  timeoutMs?: number;
+}
+
+/**
+ * Error thrown when token fetching fails
+ */
+export class TokenClientError extends Error {
+  constructor(message: string, public readonly statusCode?: number) {
+    super(message);
+    this.name = 'TokenClientError';
+  }
+}
+
+/**
+ * Client for fetching authentication tokens from Shopify's auth service
+ */
+export class TokenClient {
+  private config: TokenClientConfig;
+
+  constructor(config?: Partial<TokenClientConfig>) {
+    this.config = {
+      clientId: config?.clientId || Config.SHOPIFY_CLIENT_ID || '',
+      clientSecret: config?.clientSecret || Config.SHOPIFY_CLIENT_SECRET || '',
+      authEndpoint: config?.authEndpoint || Config.SHOPIFY_AUTH_ENDPOINT || '',
+      timeoutMs: config?.timeoutMs || 10000,
+    };
+  }
+
+  /**
+   * Check if the client is properly configured
+   */
+  isConfigured(): boolean {
+    return Boolean(
+      this.config.clientId &&
+      this.config.clientSecret &&
+      this.config.authEndpoint
+    );
+  }
+
+  /**
+   * Fetch an access token from the Shopify auth service
+   * @returns Access token string, or undefined if not configured or failed
+   */
+  async fetchToken(): Promise<string | undefined> {
+    // Skip if credentials are not configured
+    if (!this.isConfigured()) {
+      console.warn('TokenClient: Missing credentials - skipping token fetch');
+      return undefined;
+    }
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), this.config.timeoutMs);
+
+      const response = await fetch(this.config.authEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          client_id: this.config.clientId,
+          client_secret: this.config.clientSecret,
+          grant_type: 'client_credentials',
+        }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        throw await this.createHttpError(response);
+      }
+
+      const data = await this.parseResponse(response);
+      this.validateTokenResponse(data);
+
+      return data.access_token;
+    } catch (error) {
+      this.handleError(error);
+      return undefined;
+    }
+  }
+
+  /**
+   * Create a descriptive error for HTTP failures
+   */
+  private async createHttpError(response: Response): Promise<TokenClientError> {
+    // Try to get error details from response body
+    let errorMessage = `Failed to fetch access token: ${response.status} ${response.statusText}`;
+
+    try {
+      const errorBody = await response.text();
+      if (errorBody) {
+        errorMessage += ` - ${errorBody}`;
+      }
+    } catch {
+      // Ignore errors when trying to read error response
+    }
+
+    // Provide more specific error messages for common HTTP status codes
+    switch (response.status) {
+      case 401:
+        errorMessage = 'Authentication failed: Invalid client credentials';
+        break;
+      case 403:
+        errorMessage = 'Access denied: Check client permissions and scopes';
+        break;
+      case 429:
+        errorMessage = 'Rate limit exceeded: Too many requests, please try again later';
+        break;
+      default:
+        if (response.status >= 500) {
+          errorMessage = 'Server error: Authentication service is temporarily unavailable';
+        }
+        break;
+    }
+
+    return new TokenClientError(errorMessage, response.status);
+  }
+
+  /**
+   * Parse the JSON response safely
+   */
+  private async parseResponse(response: Response): Promise<AccessTokenResponse> {
+    try {
+      return await response.json();
+    } catch (jsonError) {
+      throw new TokenClientError('Invalid response format: Unable to parse authentication response');
+    }
+  }
+
+  /**
+   * Validate the token response structure
+   */
+  private validateTokenResponse(data: AccessTokenResponse): void {
+    if (!data.access_token || typeof data.access_token !== 'string') {
+      throw new TokenClientError('Invalid response: Missing or invalid access token in response');
+    }
+  }
+
+  /**
+   * Handle and log errors appropriately
+   */
+  private handleError(error: unknown): void {
+    let errorMessage = 'Unknown error occurred while fetching authentication token';
+
+    if (error instanceof TokenClientError) {
+      errorMessage = error.message;
+    } else if (error instanceof Error) {
+      if (error.name === 'AbortError') {
+        errorMessage = 'Request timeout: Authentication service took too long to respond';
+      } else if (error.message.includes('Network request failed') || error.message.includes('Failed to fetch')) {
+        errorMessage = 'Network error: Unable to connect to authentication service';
+      } else {
+        errorMessage = error.message;
+      }
+    }
+
+    console.error('TokenClient: Error fetching auth token:', errorMessage, error);
+  }
+}
+
+/**
+ * Default token client instance using environment configuration
+ */
+export const defaultTokenClient = new TokenClient();
+
+/**
+ * Convenience function for fetching a token with the default client
+ */
+export const fetchToken = (): Promise<string | undefined> => {
+  return defaultTokenClient.fetchToken();
+};
+


### PR DESCRIPTION
### What changes are you making?

1. Update <Checkout> to take an `auth` prop, rather than `options`
2. Ensure we call invalidate when auth token or URL changes in RCTCheckoutWebView 
3. Move token fetching to before the navigation, to prevent re-renders

Part of the issue is that previously the <Checkout> component was being created multiple times, e.g.

- once with a URL and undefined token
- then later (when a token had been fetched) with a URL and defined token

Combined with preloading and a missing invalidate this can cause issues.

---

We also saw an issue where  color scheme changes weren't being reflected in the UI, so have looked at fixing that by moving ConfigProvider up and adding an effect to watch `appConfig.colorScheme`

### PR Checklist

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
