### PR TITLE
[Sample] fix: ios cart alignment

### DIFF
--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -36,6 +36,7 @@ import {
   Linking,
   Pressable,
   StatusBar,
+  StyleSheet,
 } from 'react-native';
 import Icon from 'react-native-vector-icons/Entypo';
 
@@ -102,7 +103,7 @@ export type RootStackParamList = {
   Cart: undefined;
   CartModal: undefined;
   Settings: undefined;
-  BuyNow: {url: string, auth: string};
+  BuyNow: {url: string; auth: string};
 };
 
 const Tab = createBottomTabNavigator<RootStackParamList>();
@@ -306,7 +307,7 @@ function CartIcon({onPress}: {onPress: () => void}) {
   const theme = useTheme();
 
   return (
-    <Pressable onPress={onPress}>
+    <Pressable onPress={onPress} style={styles.cart}>
       <Icon name="shopping-basket" size={24} color={theme.colors.secondary} />
     </Pressable>
   );
@@ -522,3 +523,12 @@ function App() {
 }
 
 export default App;
+
+const styles = StyleSheet.create({
+  cart: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    minWidth: 36,
+    minHeight: 36,
+  },
+});


### PR DESCRIPTION
### What changes are you making?

react native screens has an issue with ios 26: https://github.com/software-mansion/react-native-screens/issues/2990

header items are not aligning properly 


before
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/709fcc6c-6206-4d36-a7be-4047ad803097" />

after
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/4c041060-72cc-4736-b096-5e220c92eea7" />

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
