### PR TITLE
Refactor: Migrate `__typename` to `type`

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/src/events.d.ts
+++ b/modules/@shopify/checkout-sheet-kit/src/events.d.ts
@@ -270,6 +270,8 @@ export type CartAddress = CartSelectableAddress;
  * Remote token payment credential for delegated payment processing.
  */
 export interface RemoteTokenPaymentCredential {
+  /** Discriminator for credential type */
+  type: 'remoteToken';
   /** The payment token */
   token: string;
   /** The type of token (e.g., "card") */
@@ -279,12 +281,10 @@ export interface RemoteTokenPaymentCredential {
 }
 
 /**
- * Cart credential containing payment authentication data.
+ * Payment credential types.
+ * Uses discriminated union pattern for extensibility.
  */
-export interface CartCredential {
-  /** Remote token payment credential for tokenized payments */
-  remoteTokenPaymentCredential?: RemoteTokenPaymentCredential;
-}
+export type PaymentCredential = RemoteTokenPaymentCredential;
 
 /**
  * Payment instrument available for selection at checkout.
@@ -293,12 +293,10 @@ export interface CartCredential {
  * @see https://shopify.dev/docs/api/storefront/latest/objects/CartPaymentInstrument
  */
 export interface CartPaymentInstrument {
-  /** Type discriminator for the payment instrument */
-  __typename?: string;
   /** Unique identifier for this payment instrument */
   externalReferenceId: string;
   /** Payment credentials for this instrument */
-  credentials?: CartCredential[];
+  credentials?: PaymentCredential[];
   /** Name of the cardholder */
   cardHolderName?: string;
   /** Last digits of the card number */
@@ -315,10 +313,11 @@ export interface CartPaymentInstrument {
 
 /**
  * A payment method containing payment instruments.
+ * Uses discriminated union pattern for extensibility.
  */
 export interface CartPaymentMethod {
-  /** Type discriminator (e.g., "CreditCardPaymentMethod") */
-  __typename?: string;
+  /** Discriminator for payment method type */
+  type: 'creditCard';
   /** Payment instruments for this method */
   instruments: CartPaymentInstrument[];
 }

--- a/modules/@shopify/checkout-sheet-kit/src/index.ts
+++ b/modules/@shopify/checkout-sheet-kit/src/index.ts
@@ -501,7 +501,7 @@ export type {
 export type {
   Cart,
   CartAddress,
-  CartCredential,
+  PaymentCredential,
   CartPayment,
   CartPaymentInstrument,
   CartPaymentMethod,

--- a/sample/src/screens/BuyNow/CheckoutScreen.tsx
+++ b/sample/src/screens/BuyNow/CheckoutScreen.tsx
@@ -67,16 +67,16 @@ export default function CheckoutScreen(props: {
           payment: {
             methods: [
               {
+                type: 'creditCard',
                 instruments: [
                   {
                     externalReferenceId: 'payment-instrument-123',
                     credentials: [
                       {
-                        remoteTokenPaymentCredential: {
-                          token: '1234567890',
-                          tokenType: 'delegated',
-                          tokenHandler: 'shopify',
-                        },
+                        type: 'remoteToken',
+                        token: '1234567890',
+                        tokenType: 'delegated',
+                        tokenHandler: 'shopify',
                       },
                     ],
                   },

--- a/sample/src/screens/BuyNow/PaymentScreen.tsx
+++ b/sample/src/screens/BuyNow/PaymentScreen.tsx
@@ -115,6 +115,7 @@ export default function PaymentScreen() {
         payment: {
           methods: [
             {
+              type: 'creditCard',
               instruments: [selectedPayment.instrument],
             },
           ],


### PR DESCRIPTION
### What changes are you making?


  This PR removes GraphQL-isms from the communication protocol, specifically migrating away from `__typename` fields in favor of simpler type discriminators.

  Changes:
  - CartPaymentMethod: Replace `__typename` with `type` field
  - CartPaymentInstrument: Remove `__typename` field entirely
  - CartCredential: Flatten wrapper class into a type alias for RemoteTokenPaymentCredential, adding type field directly

  This simplifies the public API and aligns with the protocol's move away from GraphQL conventions.

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
