### PR TITLE
rename onError to onFail for consistency

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/android/src/main/java/com/shopify/reactnative/checkoutsheetkit/CheckoutEventType.java
+++ b/modules/@shopify/checkout-sheet-kit/android/src/main/java/com/shopify/reactnative/checkoutsheetkit/CheckoutEventType.java
@@ -39,7 +39,7 @@ package com.shopify.reactnative.checkoutsheetkit;
  */
 public enum CheckoutEventType {
   ON_START("onStart"),
-  ON_ERROR("onError"),
+  ON_FAIL("onFail"),
   ON_COMPLETE("onComplete"),
   ON_CANCEL("onCancel"),
   ON_LINK_CLICK("onLinkClick"),

--- a/modules/@shopify/checkout-sheet-kit/android/src/main/java/com/shopify/reactnative/checkoutsheetkit/RCTCheckoutWebView.java
+++ b/modules/@shopify/checkout-sheet-kit/android/src/main/java/com/shopify/reactnative/checkoutsheetkit/RCTCheckoutWebView.java
@@ -322,7 +322,7 @@ public class RCTCheckoutWebView extends FrameLayout {
 
     @Override
     public void onFail(@NonNull CheckoutException error) {
-      sendEvent(CheckoutEventType.ON_ERROR, buildErrorMap(error));
+      sendEvent(CheckoutEventType.ON_FAIL, buildErrorMap(error));
     }
 
     @Override

--- a/modules/@shopify/checkout-sheet-kit/android/src/test/java/com/shopify/reactnative/checkoutsheetkit/RCTCheckoutWebViewManagerTest.java
+++ b/modules/@shopify/checkout-sheet-kit/android/src/test/java/com/shopify/reactnative/checkoutsheetkit/RCTCheckoutWebViewManagerTest.java
@@ -217,7 +217,7 @@ public class RCTCheckoutWebViewManagerTest {
             .containsKeys(
                 "onStart",
                 "onComplete",
-                "onError",
+                "onFail",
                 "onCancel",
                 "onLinkClick",
                 "onAddressChangeStart",

--- a/modules/@shopify/checkout-sheet-kit/ios/RCTCheckoutWebView.swift
+++ b/modules/@shopify/checkout-sheet-kit/ios/RCTCheckoutWebView.swift
@@ -87,7 +87,7 @@ class RCTCheckoutWebView: UIView {
     }
 
     @objc var onStart: RCTBubblingEventBlock?
-    @objc var onError: RCTBubblingEventBlock?
+    @objc var onFail: RCTBubblingEventBlock?
     @objc var onComplete: RCTBubblingEventBlock?
     @objc var onCancel: RCTBubblingEventBlock?
     @objc var onLinkClick: RCTBubblingEventBlock?
@@ -246,7 +246,7 @@ class RCTCheckoutWebView: UIView {
             errorCode = "UNKNOWN_ERROR"
         }
 
-        onError?([
+        onFail?([
             "error": errorMessage,
             "eventId": id,
             "code": errorCode
@@ -276,7 +276,7 @@ extension RCTCheckoutWebView: CheckoutDelegate {
     }
 
     func checkoutDidFail(error: ShopifyCheckoutSheetKit.CheckoutError) {
-        onError?(ShopifyEventSerialization.serialize(checkoutError: error))
+        onFail?(ShopifyEventSerialization.serialize(checkoutError: error))
     }
 
     func checkoutDidClickLink(url: URL) {

--- a/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.mm
+++ b/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.mm
@@ -106,7 +106,7 @@ SOFTWARE.
     /**
      * Emitted when checkout fails
      */
-    RCT_EXPORT_VIEW_PROPERTY(onError, RCTDirectEventBlock)
+    RCT_EXPORT_VIEW_PROPERTY(onFail, RCTBubblingEventBlock)
 
     /**
      * Emitted when checkout completes successfully

--- a/modules/@shopify/checkout-sheet-kit/src/components/Checkout.tsx
+++ b/modules/@shopify/checkout-sheet-kit/src/components/Checkout.tsx
@@ -129,7 +129,7 @@ interface NativeShopifyCheckoutWebViewProps {
   style?: ViewStyle;
   testID?: string;
   onStart?: (event: {nativeEvent: CheckoutStartEvent}) => void;
-  onError?: (event: {nativeEvent: CheckoutNativeError}) => void;
+  onFail?: (event: {nativeEvent: CheckoutNativeError}) => void;
   onComplete?: (event: {nativeEvent: CheckoutCompleteEvent}) => void;
   onCancel?: () => void;
   onLinkClick?: (event: {nativeEvent: {url: string}}) => void;
@@ -232,7 +232,7 @@ export const ShopifyCheckout = forwardRef<
     );
 
     const handleError = useCallback<
-      Required<NativeShopifyCheckoutWebViewProps>['onError']
+      Required<NativeShopifyCheckoutWebViewProps>['onFail']
     >(
       event => {
         const transformedError = parseCheckoutError(event.nativeEvent);
@@ -322,7 +322,7 @@ export const ShopifyCheckout = forwardRef<
         style={style}
         testID={testID}
         onStart={handleStart}
-        onError={handleError}
+        onFail={handleError}
         onComplete={handleComplete}
         onCancel={handleCancel}
         onLinkClick={handleLinkClick}

--- a/modules/@shopify/checkout-sheet-kit/tests/CheckoutError.test.tsx
+++ b/modules/@shopify/checkout-sheet-kit/tests/CheckoutError.test.tsx
@@ -51,7 +51,7 @@ describe('Checkout Component - Error Events', () => {
       const nativeComponent = getByTestId('checkout-webview');
 
       act(() => {
-        nativeComponent.props.onError({
+        nativeComponent.props.onFail({
           nativeEvent: {
             __typename: 'ConfigurationError',
             code: 'STOREFRONT_PASSWORD_REQUIRED',
@@ -88,7 +88,7 @@ describe('Checkout Component - Error Events', () => {
       const nativeComponent = getByTestId('checkout-webview');
 
       act(() => {
-        nativeComponent.props.onError({
+        nativeComponent.props.onFail({
           nativeEvent: {
             __typename: 'CheckoutClientError',
             code: 'KILLSWITCH_ENABLED',
@@ -121,7 +121,7 @@ describe('Checkout Component - Error Events', () => {
       const nativeComponent = getByTestId('checkout-webview');
 
       act(() => {
-        nativeComponent.props.onError({
+        nativeComponent.props.onFail({
           nativeEvent: {
             __typename: 'CheckoutExpiredError',
             code: 'CART_COMPLETED',
@@ -171,7 +171,7 @@ describe('Checkout Component - Error Events', () => {
         const nativeComponent = getByTestId('checkout-webview');
 
         act(() => {
-          nativeComponent.props.onError({
+          nativeComponent.props.onFail({
             nativeEvent: {
               __typename: 'ConfigurationError',
               code: nativeCode,
@@ -196,7 +196,7 @@ describe('Checkout Component - Error Events', () => {
 
     expect(() => {
       act(() => {
-        nativeComponent.props.onError({
+        nativeComponent.props.onFail({
           nativeEvent: {
             __typename: 'ConfigurationError',
             code: 'STOREFRONT_PASSWORD_REQUIRED',
@@ -223,7 +223,7 @@ describe('Checkout Component - Error Events', () => {
       const nativeComponent = getByTestId('checkout-webview');
 
       act(() => {
-        nativeComponent.props.onError({
+        nativeComponent.props.onFail({
           nativeEvent: {
             __typename: 'ConfigurationError',
             code: 'INVALID_PAYLOAD',
@@ -260,7 +260,7 @@ describe('Checkout Component - Error Events', () => {
       const nativeComponent = getByTestId('checkout-webview');
 
       act(() => {
-        nativeComponent.props.onError({
+        nativeComponent.props.onFail({
           nativeEvent: {
             __typename: 'CheckoutClientError',
             code: 'UNRECOVERABLE_FAILURE',
@@ -297,7 +297,7 @@ describe('Checkout Component - Error Events', () => {
       const nativeComponent = getByTestId('checkout-webview');
 
       act(() => {
-        nativeComponent.props.onError({
+        nativeComponent.props.onFail({
           nativeEvent: {
             __typename: 'CheckoutExpiredError',
             code: 'INVALID_CART',
@@ -334,7 +334,7 @@ describe('Checkout Component - Error Events', () => {
       const nativeComponent = getByTestId('checkout-webview');
 
       act(() => {
-        nativeComponent.props.onError({
+        nativeComponent.props.onFail({
           nativeEvent: {
             __typename: 'CheckoutHTTPError',
             code: 'http_error',
@@ -372,7 +372,7 @@ describe('Checkout Component - Error Events', () => {
       const nativeComponent = getByTestId('checkout-webview');
 
       act(() => {
-        nativeComponent.props.onError({
+        nativeComponent.props.onFail({
           nativeEvent: {
             __typename: 'InternalError',
             code: 'error_sending_message',
@@ -408,7 +408,7 @@ describe('Checkout Component - Error Events', () => {
       const nativeComponent = getByTestId('checkout-webview');
 
       act(() => {
-        nativeComponent.props.onError({
+        nativeComponent.props.onFail({
           nativeEvent: {
             __typename: 'SomeUnknownErrorType',
             code: 'some_unknown_code',
@@ -444,7 +444,7 @@ describe('Checkout Component - Error Events', () => {
       const nativeComponent = getByTestId('checkout-webview');
 
       act(() => {
-        nativeComponent.props.onError({
+        nativeComponent.props.onFail({
           nativeEvent: {
             __typename: 'UnknownError',
             code: 'unknown',

--- a/sample/src/screens/BuyNow/CheckoutScreen.tsx
+++ b/sample/src/screens/BuyNow/CheckoutScreen.tsx
@@ -96,8 +96,8 @@ export default function CheckoutScreen(props: {
     navigation.getParent()?.goBack();
   };
 
-  const onError = (error: unknown) => {
-    console.log('<CheckoutScreen /> onError: ', error);
+  const onFail = (error: unknown) => {
+    console.log('<CheckoutScreen /> onFail: ', error);
     ref.current?.reload();
   };
 
@@ -117,7 +117,7 @@ export default function CheckoutScreen(props: {
       onPaymentMethodChangeStart={onPaymentMethodChangeStart}
       onSubmitStart={onSubmitStart}
       onCancel={onCancel}
-      onError={onError}
+      onFail={onFail}
       onComplete={onComplete}
     />
   );


### PR DESCRIPTION
### What changes are you making?

Optional change, opening for awareness of the inconsistency.

```swift
    @discardableResult public func onFail(_ action: @escaping (CheckoutError) -> Void) -> Self {
        delegate.onFail = action
        return self
    }
```

```kt
    override fun onFail(error: CheckoutException) {
```

I tested by adding in a throw when opening the sheets from the native side, and seeing that they propagate to the react native handler in the js debugger:

ios

<img width="537" height="140" alt="image" src="https://github.com/user-attachments/assets/56406537-fdd0-42ae-8dda-8902d303ce14" />


android
<img width="876" height="110" alt="image" src="https://github.com/user-attachments/assets/86970da2-9af5-4348-8ace-eff05e733303" />


### PR Checklist

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
