### PR TITLE
Add missing imperative API payment method change start event

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/src/index.d.ts
+++ b/modules/@shopify/checkout-sheet-kit/src/index.d.ts
@@ -153,6 +153,7 @@ export type CheckoutEvent =
   | 'start'
   | 'error'
   | 'addressChangeStart'
+  | 'paymentMethodChangeStart'
   | 'submitStart'
   | 'geolocationRequest';
 
@@ -174,6 +175,9 @@ export type CheckoutStartEventCallback = (
 export type CheckoutAddressChangeStartCallback = (
   event: CheckoutAddressChangeStartEvent,
 ) => void;
+export type CheckoutPaymentMethodChangeStartCallback = (
+  event: CheckoutPaymentMethodChangeStartEvent,
+) => void;
 export type CheckoutSubmitStartCallback = (
   event: CheckoutSubmitStartEvent,
 ) => void;
@@ -185,6 +189,7 @@ export type CheckoutEventCallback =
   | CheckoutStartEventCallback
   | CheckoutAddressChangeStartCallback
   | CheckoutSubmitStartCallback
+  | CheckoutPaymentMethodChangeStartCallback
   | GeolocationRequestEventCallback;
 
 /**
@@ -266,6 +271,11 @@ function addEventListener(
 function addEventListener(
   event: 'addressChangeStart',
   callback: CheckoutAddressChangeStartCallback,
+): Maybe<EmitterSubscription>;
+
+function addEventListener(
+  event: 'paymentMethodChangeStart',
+  callback: CheckoutPaymentMethodChangeStartCallback,
 ): Maybe<EmitterSubscription>;
 
 function addEventListener(

--- a/modules/@shopify/checkout-sheet-kit/src/index.ts
+++ b/modules/@shopify/checkout-sheet-kit/src/index.ts
@@ -180,6 +180,24 @@ class ShopifyCheckoutSheet implements ShopifyCheckoutSheetKit {
     let eventCallback;
 
     switch (event) {
+      case 'complete':
+        eventCallback = this.parseEventData('complete', callback);
+        break;
+      case 'start':
+        eventCallback = this.parseEventData('start', callback);
+        break;
+      case 'addressChangeStart':
+        eventCallback = this.parseEventData('addressChangeStart', callback);
+        break;
+      case 'submitStart':
+        eventCallback = this.parseEventData('submitStart', callback);
+        break;
+      case 'paymentMethodChangeStart':
+        eventCallback = this.parseEventData(
+          'paymentMethodChangeStart',
+          callback,
+        );
+        break;
       case 'error':
         eventCallback = this.parseEventData(
           event,

--- a/modules/@shopify/checkout-sheet-kit/tests/index.test.ts
+++ b/modules/@shopify/checkout-sheet-kit/tests/index.test.ts
@@ -469,6 +469,61 @@ describe('ShopifyCheckoutSheetKit', () => {
       });
     });
 
+    describe('Payment Method Change Start Event', () => {
+      it('parses paymentMethodChangeStart event data', () => {
+        const instance = new ShopifyCheckoutSheet();
+        const callback = jest.fn();
+        instance.addEventListener('paymentMethodChangeStart', callback);
+
+        eventEmitter.emit('paymentMethodChangeStart', {
+          id: 'test-event-id',
+          method: 'checkout.paymentMethodChangeStart',
+          cart: {id: 'test-cart-id'},
+        });
+
+        expect(callback).toHaveBeenCalledWith({
+          id: 'test-event-id',
+          method: 'checkout.paymentMethodChangeStart',
+          cart: {id: 'test-cart-id'},
+        });
+      });
+
+      it('parses paymentMethodChangeStart event string data as JSON', () => {
+        const instance = new ShopifyCheckoutSheet();
+        const callback = jest.fn();
+        instance.addEventListener('paymentMethodChangeStart', callback);
+
+        eventEmitter.emit(
+          'paymentMethodChangeStart',
+          JSON.stringify({
+            id: 'test-event-id',
+            method: 'checkout.paymentMethodChangeStart',
+            cart: {id: 'test-cart-id'},
+          }),
+        );
+
+        expect(callback).toHaveBeenCalledWith({
+          id: 'test-event-id',
+          method: 'checkout.paymentMethodChangeStart',
+          cart: {id: 'test-cart-id'},
+        });
+      });
+
+      it('prints an error if the paymentMethodChangeStart event data cannot be parsed', () => {
+        const mock = jest.spyOn(global.console, 'error');
+        const instance = new ShopifyCheckoutSheet();
+        const callback = jest.fn();
+        instance.addEventListener('paymentMethodChangeStart', callback);
+
+        eventEmitter.emit('paymentMethodChangeStart', 'INVALID JSON');
+
+        expect(mock).toHaveBeenCalledWith(
+          expect.any(LifecycleEventParseError),
+          'INVALID JSON',
+        );
+      });
+    });
+
     describe('Error Event', () => {
       const internalError = {
         __typename: CheckoutNativeErrorType.InternalError,

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -236,6 +236,16 @@ function AppWithContext({children}: PropsWithChildren) {
       },
     );
 
+    const paymentMethodChangeStart = shopify.addEventListener(
+      'paymentMethodChangeStart',
+      event => {
+        console.log(
+          '[App] onPaymentMethodChangeStart event received from imperative API:',
+          event,
+        );
+      },
+    );
+
     const error = shopify.addEventListener(
       'error',
       (error: CheckoutException) => {
@@ -247,6 +257,7 @@ function AppWithContext({children}: PropsWithChildren) {
       completed?.remove();
       started?.remove();
       addressChangeStart?.remove();
+      paymentMethodChangeStart?.remove();
       close?.remove();
       error?.remove();
     };


### PR DESCRIPTION
### What changes are you making?

The imperative API was missing the paymentMethodChangeStart event listener

Testing in sample app shows the event is now received
<img width="942" height="49" alt="image" src="https://github.com/user-attachments/assets/134f9550-d756-4fc2-9c06-c53d78f129aa" />


---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
