### PR TITLE
Add onLinkClick global event (imperative api)

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/android/src/main/java/com/shopify/reactnative/checkoutsheetkit/SheetCheckoutEventProcessor.java
+++ b/modules/@shopify/checkout-sheet-kit/android/src/main/java/com/shopify/reactnative/checkoutsheetkit/SheetCheckoutEventProcessor.java
@@ -24,6 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 package com.shopify.reactnative.checkoutsheetkit;
 
 import android.content.Context;
+import android.net.Uri;
 import android.util.Log;
 import android.webkit.GeolocationPermissions;
 
@@ -209,6 +210,17 @@ public class SheetCheckoutEventProcessor extends DefaultCheckoutEventProcessor {
       sendEventWithStringData("submitStart", data);
     } catch (IOException e) {
       Log.e(TAG, "Error processing submit start event", e);
+    }
+  }
+
+  @Override
+  public void onLinkClick(@NonNull Uri uri) {
+    try {
+      Map<String, Object> event = new HashMap<>();
+      event.put("url", uri.toString());
+      sendEventWithStringData("linkClick", mapper.writeValueAsString(event));
+    } catch (IOException e) {
+      Log.e(TAG, "Error processing link click event", e);
     }
   }
 

--- a/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.swift
+++ b/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.swift
@@ -52,6 +52,7 @@ class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
         case paymentMethodChangeStart
         case start
         case submitStart
+        case linkClick
     }
 
     override init() {
@@ -108,6 +109,10 @@ class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
 
             self.checkoutSheet?.dismiss(animated: true)
         }
+    }
+
+    func checkoutDidClickLink(url: URL) {
+        emit(event: .linkClick, body: ["url": url.absoluteString])
     }
 
     @objc override func constantsToExport() -> [AnyHashable: Any]! {

--- a/modules/@shopify/checkout-sheet-kit/src/index.d.ts
+++ b/modules/@shopify/checkout-sheet-kit/src/index.d.ts
@@ -154,16 +154,22 @@ export type CheckoutEvent =
   | 'error'
   | 'addressChangeStart'
   | 'submitStart'
-  | 'geolocationRequest';
+  | 'geolocationRequest'
+  | 'linkClick';
 
 export interface GeolocationRequestEvent {
   origin: string;
+}
+
+export interface LinkClickEvent {
+  url: string;
 }
 
 export type CloseEventCallback = () => void;
 export type GeolocationRequestEventCallback = (
   event: GeolocationRequestEvent,
 ) => void;
+export type LinkClickEventCallback = (event: LinkClickEvent) => void;
 export type CheckoutExceptionCallback = (error: CheckoutException) => void;
 export type CheckoutCompleteEventCallback = (
   event: CheckoutCompleteEvent,
@@ -185,7 +191,8 @@ export type CheckoutEventCallback =
   | CheckoutStartEventCallback
   | CheckoutAddressChangeStartCallback
   | CheckoutSubmitStartCallback
-  | GeolocationRequestEventCallback;
+  | GeolocationRequestEventCallback
+  | LinkClickEventCallback;
 
 /**
  * Available wallet types for accelerated checkout
@@ -281,6 +288,11 @@ function addEventListener(
 function addEventListener(
   event: 'geolocationRequest',
   callback: GeolocationRequestEventCallback,
+): Maybe<EmitterSubscription>;
+
+function addEventListener(
+  event: 'linkClick',
+  callback: LinkClickEventCallback,
 ): Maybe<EmitterSubscription>;
 
 function removeEventListeners(event: CheckoutEvent): void;

--- a/modules/@shopify/checkout-sheet-kit/src/index.ts
+++ b/modules/@shopify/checkout-sheet-kit/src/index.ts
@@ -43,6 +43,7 @@ import type {
   Configuration,
   Features,
   GeolocationRequestEvent,
+  LinkClickEvent,
   Maybe,
   ShopifyCheckoutSheetKit,
 } from './index.d';
@@ -207,6 +208,9 @@ class ShopifyCheckoutSheet implements ShopifyCheckoutSheetKit {
           'geolocationRequest',
           callback,
         );
+        break;
+      case 'linkClick':
+        eventCallback = this.interceptEventEmission('linkClick', callback);
         break;
       default:
         eventCallback = callback;
@@ -475,6 +479,7 @@ export type {
   Configuration,
   Features,
   GeolocationRequestEvent,
+  LinkClickEvent,
 };
 
 // Event types

--- a/modules/@shopify/checkout-sheet-kit/tests/index.test.ts
+++ b/modules/@shopify/checkout-sheet-kit/tests/index.test.ts
@@ -458,6 +458,42 @@ describe('ShopifyCheckoutSheetKit', () => {
       });
     });
 
+    describe('LinkClick Event', () => {
+      it('parses linkClick event string data as JSON', () => {
+        const instance = new ShopifyCheckoutSheet();
+        const callback = jest.fn();
+        instance.addEventListener('linkClick', callback);
+
+        eventEmitter.emit(
+          'linkClick',
+          JSON.stringify({url: 'https://example.com/terms'}),
+        );
+        expect(callback).toHaveBeenCalledWith({url: 'https://example.com/terms'});
+      });
+
+      it('parses linkClick event JSON data', () => {
+        const instance = new ShopifyCheckoutSheet();
+        const callback = jest.fn();
+        instance.addEventListener('linkClick', callback);
+
+        eventEmitter.emit('linkClick', {url: 'https://example.com/privacy'});
+        expect(callback).toHaveBeenCalledWith({url: 'https://example.com/privacy'});
+      });
+
+      it('prints an error if the linkClick event data cannot be parsed', () => {
+        const mock = jest.spyOn(global.console, 'error');
+        const instance = new ShopifyCheckoutSheet();
+        const callback = jest.fn();
+        instance.addEventListener('linkClick', callback);
+
+        eventEmitter.emit('linkClick', 'INVALID JSON');
+        expect(mock).toHaveBeenCalledWith(
+          expect.any(LifecycleEventParseError),
+          'INVALID JSON',
+        );
+      });
+    });
+
     describe('Error Event', () => {
       const internalError = {
         __typename: CheckoutNativeErrorType.InternalError,

--- a/sample/ios/ReactNativeTests/ShopifyCheckoutSheetKitTests.swift
+++ b/sample/ios/ReactNativeTests/ShopifyCheckoutSheetKitTests.swift
@@ -250,6 +250,20 @@ class ShopifyCheckoutSheetKitTests: XCTestCase {
         XCTAssertTrue((mock.checkoutSheet as! MockCheckoutSheet).dismissWasCalled)
     }
 
+    /// checkoutDidClickLink
+    func testCheckoutDidClickLinkSendsEvent() {
+        let mock = mockSendEvent(eventName: "linkClick")
+
+        mock.startObserving()
+
+        let testURL = URL(string: "https://example.com/terms")!
+        mock.checkoutDidClickLink(url: testURL)
+
+        XCTAssertTrue(mock.didSendEvent)
+        let body = mock.eventBody as? [String: String]
+        XCTAssertEqual(body?["url"], "https://example.com/terms")
+    }
+
     /// CheckoutOptions parsing
     func testCanPresentCheckoutWithAuthenticationOptions() {
         let options: [AnyHashable: Any] = [

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -243,12 +243,17 @@ function AppWithContext({children}: PropsWithChildren) {
       },
     );
 
+    const linkClick = shopify.addEventListener('linkClick', event => {
+      console.log('[App] linkClick event received:', event.url);
+    });
+
     return () => {
       completed?.remove();
       started?.remove();
       addressChangeStart?.remove();
       close?.remove();
       error?.remove();
+      linkClick?.remove();
     };
   }, [shopify, eventHandlers]);
 


### PR DESCRIPTION
### What changes are you making?

Adds linkClick eventListener type for use in imperative api (`.present()`)

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
