### PR TITLE
Fix link for custom Web Pixel events

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,9 +648,9 @@ and log the status of a checkout session.
 
 For behavioural monitoring,
 ["standard"](https://shopify.dev/docs/api/web-pixels-api/standard-events) and
-["custom"](https://shopify.dev/docs/api/web-pixels-api/emitting-data) Web
+["custom"](https://shopify.dev/docs/api/web-pixels-api#custom-web-pixels) Web
 Pixel events normally available to web pixels will be relayed back to your
-application through the "pixel" event listener. Web pixels do not execute
+application through the "pixel" event listener, see: [subscribing to custom events](https://shopify.dev/docs/api/web-pixels-api/emitting-data). Web pixels do not execute
 in checkout sheet kit checkouts.
 App developers should only subscribe to pixel events if they have proper levels of consent from merchants/buyers and are responsible for adherence to Apple's privacy policy and local regulations like GDPR and
 ePrivacy directive before disseminating these events to first-party and


### PR DESCRIPTION
### What changes are you making?

- Updated link for custom Web Pixel events documentation. Custom pixels have nothing to do with the events checkout sheet kit relays to the application, the docs intend to refer to custom events that can be emitted by the online store, UI extensions, etc.
- Clarify that web pixels do not execute during checkout sheet kit checkouts.

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
