### PR TITLE
Revert "Fix link for custom Web Pixel events"

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,10 +652,8 @@ and log the status of a checkout session.
 For behavioural monitoring,
 ["standard"](https://shopify.dev/docs/api/web-pixels-api/standard-events) and
 ["custom"](https://shopify.dev/docs/api/web-pixels-api#custom-web-pixels) Web
-Pixel events normally available to web pixels will be relayed back to your
-application through the "pixel" event listener, see: [subscribing to custom events](https://shopify.dev/docs/api/web-pixels-api/emitting-data). Web pixels do not execute
-in checkout sheet kit checkouts.
-App developers should only subscribe to pixel events if they have proper levels of consent from merchants/buyers and are responsible for adherence to Apple's privacy policy and local regulations like GDPR and
+Pixel events will be relayed back to your application through the `"pixel"`
+event listener. App developers should only subscribe to pixel events if they have proper levels of consent from merchants/buyers and are responsible for adherence to Apple's privacy policy and local regulations like GDPR and
 ePrivacy directive before disseminating these events to first-party and
 third-party systems.
 


### PR DESCRIPTION
Reverts Shopify/checkout-sheet-kit-react-native#425

Web pixels are in fact executing, but the events are passed through to the relevant event listener instead