### PR TITLE
Fix CI release process - update publish workflow to use OIDC authentication

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,7 +7,13 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
       with:
-        node-version: 20
+        node-version: 22
+        registry-url: 'https://registry.npmjs.org'
+
+    # TODO: Can be removed once node-version is 24 as this will be the minimum
+    - name: Install npm 11
+      run: npm install -g npm@11
+      shell: bash
 
     - name: Cache turbo build setup
       uses: actions/cache@v4
@@ -24,7 +30,8 @@ runs:
         path: |
           **/node_modules
           .yarn/install-state.gz
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/package.json') }}
+        key:
+          ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/package.json') }}
         restore-keys: |
           ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           ${{ runner.os }}-yarn-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -34,11 +37,10 @@ jobs:
 
       - name: Prepare release
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
           cp README.md modules/@shopify/checkout-sheet-kit
           yarn module clean
           yarn module build
           cd modules/@shopify/checkout-sheet-kit
           npm publish --access public --tag ${{ steps.npm-tag.outputs.tag }}
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: '' # Empty string forces OIDC

--- a/dev.yml
+++ b/dev.yml
@@ -15,7 +15,7 @@ up:
         ios:
           - '26.0'
   - node:
-      version: v20.11.1
+      version: v22.14.0
       yarn: 1.22.22
   - custom:
       name: Install NPM dependencies

--- a/modules/@shopify/checkout-sheet-kit/package.json
+++ b/modules/@shopify/checkout-sheet-kit/package.json
@@ -9,6 +9,10 @@
   "description": "A React Native library for Shopify's Checkout Kit.",
   "author": "Shopify",
   "homepage": "https://github.com/shopify/checkout-sheet-kit-react-native",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Shopify/checkout-sheet-kit-react-native"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^5.9.2"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "prettier": {
     "arrowParens": "avoid",


### PR DESCRIPTION
### What changes are you making?

Classic auth has been deprecated in November 
OIDC replaces it: https://docs.npmjs.com/trusted-publishers
OIDC is available from node 22 and npm 11 
Node 22 ships by default with npm 10, so i have a manual step to bump to npm 11

## Test
Successful workflow dispatch: https://github.com/Shopify/checkout-sheet-kit-react-native/actions/runs/22351334530/job/64678972185

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
