### PR TITLE
chore: bump dev.yml to iOS 26.2

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -10,10 +10,11 @@ up:
       - ccache
   - ruby
   - xcode:
-      version: '26.1'
+      version: "26.2"
       runtimes:
         ios:
-          - '26.1'
+          - version: 23C54 # 26.2
+            architecture_variant: arm64
   - node:
       version: v22.14.0
       yarn: 1.22.22


### PR DESCRIPTION
### What changes are you making?

Dev up was failing due to the ios simulator runtime not existing - bumping to 26.2 matching the specs in admin–mobile 

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
