### PR TITLE
Bump @shopify/checkout-sheet-kit to 3.6.0

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,13 +7,8 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
       with:
-        node-version: 22
+        node-version: 24
         registry-url: 'https://registry.npmjs.org'
-
-    # TODO: Can be removed once node-version is 24 as this will be the minimum
-    - name: Install npm 11
-      run: npm install -g npm@11
-      shell: bash
 
     - name: Cache turbo build setup
       uses: actions/cache@v4

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,8 +7,13 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
       with:
-        node-version: 24
+        node-version: 22
         registry-url: 'https://registry.npmjs.org'
+
+    # TODO: Can be removed once node-version is 24 as this will be the minimum
+    - name: Install npm 11
+      run: npm install -g npm@11
+      shell: bash
 
     - name: Cache turbo build setup
       uses: actions/cache@v4

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,6 +8,7 @@ runs:
       uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
       with:
         node-version: 22
+        check-latest: true
         registry-url: 'https://registry.npmjs.org'
 
     # TODO: Can be removed once node-version is 24 as this will be the minimum

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,8 +7,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
       with:
-        node-version: 22
-        check-latest: true
+        node-version: 22.22.1
         registry-url: 'https://registry.npmjs.org'
 
     # TODO: Can be removed once node-version is 24 as this will be the minimum

--- a/modules/@shopify/checkout-sheet-kit/RNShopifyCheckoutSheetKit.podspec
+++ b/modules/@shopify/checkout-sheet-kit/RNShopifyCheckoutSheetKit.podspec
@@ -20,8 +20,8 @@ Pod::Spec.new do |s|
   s.source_files = "ios/*.{h,m,mm,swift}"
 
 	s.dependency "React-Core"
-	s.dependency "ShopifyCheckoutSheetKit", "~> 3.5.0"
-	s.dependency "ShopifyCheckoutSheetKit/AcceleratedCheckouts", "~> 3.5.0"
+	s.dependency "ShopifyCheckoutSheetKit", "~> 3.6.0"
+	s.dependency "ShopifyCheckoutSheetKit/AcceleratedCheckouts", "~> 3.6.0"
 
   if fabric_enabled
 		# Use React Native's helper if available, otherwise add dependencies directly

--- a/modules/@shopify/checkout-sheet-kit/package.json
+++ b/modules/@shopify/checkout-sheet-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-sheet-kit",
   "license": "MIT",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "main": "lib/commonjs/index.js",
   "types": "src/index.ts",
   "source": "src/index.ts",

--- a/modules/@shopify/checkout-sheet-kit/package.json
+++ b/modules/@shopify/checkout-sheet-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-sheet-kit",
   "license": "MIT",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "main": "lib/commonjs/index.js",
   "types": "src/index.ts",
   "source": "src/index.ts",

--- a/modules/@shopify/checkout-sheet-kit/package.json
+++ b/modules/@shopify/checkout-sheet-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-sheet-kit",
   "license": "MIT",
-  "version": "3.7.0",
+  "version": "3.6.0",
   "main": "lib/commonjs/index.js",
   "types": "src/index.ts",
   "source": "src/index.ts",

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -2578,7 +2578,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNShopifyCheckoutSheetKit (3.6.0):
+  - RNShopifyCheckoutSheetKit (3.7.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2996,7 +2996,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: eeb622199ef1fb3a076243131095df1c797072f0
   RNReanimated: 288616f9c66ff4b0911f3862ffcf4104482a2adc
   RNScreens: 3fc29af06302e1f1c18a7829fe57cbc2c0259912
-  RNShopifyCheckoutSheetKit: 47613bb3e98558dd948215b1e3e7c78bee1b3619
+  RNShopifyCheckoutSheetKit: cd168719464e7805f43eafd44dc9f8805933b03e
   RNVectorIcons: be4d047a76ad307ffe54732208fb0498fcb8477f
   ShopifyCheckoutSheetKit: e307ac7adc4af43ac4d041922b2073641462cd04
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -2578,7 +2578,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNShopifyCheckoutSheetKit (3.7.0):
+  - RNShopifyCheckoutSheetKit (3.6.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2996,7 +2996,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: eeb622199ef1fb3a076243131095df1c797072f0
   RNReanimated: 288616f9c66ff4b0911f3862ffcf4104482a2adc
   RNScreens: 3fc29af06302e1f1c18a7829fe57cbc2c0259912
-  RNShopifyCheckoutSheetKit: cd168719464e7805f43eafd44dc9f8805933b03e
+  RNShopifyCheckoutSheetKit: 47613bb3e98558dd948215b1e3e7c78bee1b3619
   RNVectorIcons: be4d047a76ad307ffe54732208fb0498fcb8477f
   ShopifyCheckoutSheetKit: e307ac7adc4af43ac4d041922b2073641462cd04
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -2578,7 +2578,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNShopifyCheckoutSheetKit (3.5.0):
+  - RNShopifyCheckoutSheetKit (3.6.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2605,8 +2605,8 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - ShopifyCheckoutSheetKit (~> 3.5.0)
-    - ShopifyCheckoutSheetKit/AcceleratedCheckouts (~> 3.5.0)
+    - ShopifyCheckoutSheetKit (~> 3.6.0)
+    - ShopifyCheckoutSheetKit/AcceleratedCheckouts (~> 3.6.0)
     - SocketRocket
     - Yoga
   - RNVectorIcons (10.3.0):
@@ -2638,11 +2638,11 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ShopifyCheckoutSheetKit (3.5.0):
-    - ShopifyCheckoutSheetKit/Core (= 3.5.0)
-  - ShopifyCheckoutSheetKit/AcceleratedCheckouts (3.5.0):
+  - ShopifyCheckoutSheetKit (3.6.0):
+    - ShopifyCheckoutSheetKit/Core (= 3.6.0)
+  - ShopifyCheckoutSheetKit/AcceleratedCheckouts (3.6.0):
     - ShopifyCheckoutSheetKit/Core
-  - ShopifyCheckoutSheetKit/Core (3.5.0)
+  - ShopifyCheckoutSheetKit/Core (3.6.0)
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
@@ -2996,9 +2996,9 @@ SPEC CHECKSUMS:
   RNGestureHandler: eeb622199ef1fb3a076243131095df1c797072f0
   RNReanimated: 288616f9c66ff4b0911f3862ffcf4104482a2adc
   RNScreens: 3fc29af06302e1f1c18a7829fe57cbc2c0259912
-  RNShopifyCheckoutSheetKit: 13a5ac0a5f517b7df5ee202539a82b17d82b71e4
+  RNShopifyCheckoutSheetKit: 47613bb3e98558dd948215b1e3e7c78bee1b3619
   RNVectorIcons: be4d047a76ad307ffe54732208fb0498fcb8477f
-  ShopifyCheckoutSheetKit: b63973f5aadcab5d6483871f36f3d3f19ec67e12
+  ShopifyCheckoutSheetKit: e307ac7adc4af43ac4d041922b2073641462cd04
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: a742cc68e8366fcfc681808162492bc0aa7a9498
 


### PR DESCRIPTION
### What changes are you making?

Bumps Swift dependency to 3.6.0 to include patch for Accelerated checkouts storefront api version deprecation, see release notes [here](https://github.com/Shopify/checkout-sheet-kit-swift/releases/tag/3.6.0)

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
