### PR TITLE
Support apple pay button styling

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/ios/AcceleratedCheckoutButtons+Extensions.swift
+++ b/modules/@shopify/checkout-sheet-kit/ios/AcceleratedCheckoutButtons+Extensions.swift
@@ -26,7 +26,7 @@ import Foundation
 import PassKit
 import SwiftUI
 
-// MARK: - Apple Pay Button
+// MARK: - Apple Pay Button Label
 
 @available(iOS 16.0, *)
 extension PayWithApplePayButtonLabel {
@@ -56,5 +56,25 @@ extension PayWithApplePayButtonLabel {
         "support": .support,
         "tip": .tip,
         "topUp": .topUp
+    ]
+}
+
+// MARK: - Apple Pay Button Style
+
+@available(iOS 16.0, *)
+extension PayWithApplePayButtonStyle {
+    static func from(_ string: String?) -> PayWithApplePayButtonStyle? {
+        guard let string, let value = map[string] else {
+            return nil
+        }
+
+        return value
+    }
+
+    private static let map: [String: PayWithApplePayButtonStyle] = [
+        "automatic": .automatic,
+        "black": .black,
+        "white": .white,
+        "whiteOutline": .whiteOutline
     ]
 }

--- a/modules/@shopify/checkout-sheet-kit/ios/AcceleratedCheckoutButtons.swift
+++ b/modules/@shopify/checkout-sheet-kit/ios/AcceleratedCheckoutButtons.swift
@@ -120,6 +120,12 @@ class RCTAcceleratedCheckoutButtonsView: UIView {
         }
     }
 
+    @objc var applePayStyle: String? {
+        didSet {
+            updateView()
+        }
+    }
+
     @objc var onFail: RCTBubblingEventBlock?
     @objc var onComplete: RCTBubblingEventBlock?
     @objc var onCancel: RCTBubblingEventBlock?
@@ -289,6 +295,10 @@ class RCTAcceleratedCheckoutButtonsView: UIView {
         } else {
             view = AnyView(buttons.environmentObject(config))
         }
+
+        /// Apply Apple Pay button style (defaults to .automatic)
+        let applePayButtonStyle = PayWithApplePayButtonStyle.from(applePayStyle) ?? .automatic
+        view = AnyView(view.payWithApplePayButtonStyle(applePayButtonStyle))
 
         if let hostingController {
             hostingController.rootView = view

--- a/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.mm
+++ b/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.mm
@@ -107,6 +107,11 @@ RCT_EXPORT_VIEW_PROPERTY(wallets, NSArray*)
 RCT_EXPORT_VIEW_PROPERTY(applePayLabel, NSString*)
 
 /**
+ * Style variant for the Apple Pay button (e.g., "automatic", "black", "white", "whiteOutline").
+ */
+RCT_EXPORT_VIEW_PROPERTY(applePayStyle, NSString*)
+
+/**
  * Emitted when checkout fails. Payload contains a CheckoutException-like shape.
  */
 RCT_EXPORT_VIEW_PROPERTY(onFail, RCTBubblingEventBlock)

--- a/modules/@shopify/checkout-sheet-kit/src/components/AcceleratedCheckoutButtons.tsx
+++ b/modules/@shopify/checkout-sheet-kit/src/components/AcceleratedCheckoutButtons.tsx
@@ -61,6 +61,13 @@ export enum ApplePayLabel {
   topUp = 'topUp',
 }
 
+export enum ApplePayStyle {
+  automatic = 'automatic',
+  black = 'black',
+  white = 'white',
+  whiteOutline = 'whiteOutline',
+}
+
 type CheckoutIdentifier =
   | {
       cartId: string;
@@ -86,6 +93,12 @@ interface CommonAcceleratedCheckoutButtonsProps {
    * Label for the Apple Pay button
    */
   applePayLabel?: ApplePayLabel;
+
+  /**
+   * Style for the Apple Pay button (automatic, black, white, whiteOutline)
+   * @default ApplePayStyle.automatic
+   */
+  applePayStyle?: ApplePayStyle;
 
   /**
    * Called when checkout fails
@@ -148,6 +161,7 @@ export type AcceleratedCheckoutButtonsProps = (CartProps | VariantProps) &
 
 interface NativeAcceleratedCheckoutButtonsProps {
   applePayLabel?: string;
+  applePayStyle?: string;
   style?: ViewStyle;
   checkoutIdentifier: CheckoutIdentifier;
   cornerRadius?: number;
@@ -193,6 +207,7 @@ export const AcceleratedCheckoutButtons: React.FC<
   AcceleratedCheckoutButtonsProps
 > = ({
   applePayLabel,
+  applePayStyle,
   cornerRadius,
   wallets,
   onFail,
@@ -307,6 +322,7 @@ export const AcceleratedCheckoutButtons: React.FC<
   return (
     <RCTAcceleratedCheckoutButtons
       applePayLabel={applePayLabel}
+      applePayStyle={applePayStyle}
       style={{...defaultStyles, height: dynamicHeight}}
       checkoutIdentifier={checkoutIdentifier}
       cornerRadius={cornerRadius}

--- a/modules/@shopify/checkout-sheet-kit/src/index.d.ts
+++ b/modules/@shopify/checkout-sheet-kit/src/index.d.ts
@@ -189,6 +189,13 @@ export enum ApplePayContactField {
   phone = 'phone',
 }
 
+export enum ApplePayStyle {
+  automatic = 'automatic',
+  black = 'black',
+  white = 'white',
+  whiteOutline = 'whiteOutline',
+}
+
 /**
  * Configuration for AcceleratedCheckouts
  */

--- a/modules/@shopify/checkout-sheet-kit/src/index.ts
+++ b/modules/@shopify/checkout-sheet-kit/src/index.ts
@@ -58,7 +58,10 @@ import {
 import {CheckoutErrorCode} from './errors.d';
 import type {CheckoutCompletedEvent} from './events.d';
 import type {CustomEvent, PixelEvent, StandardEvent} from './pixels.d';
-import {ApplePayLabel} from './components/AcceleratedCheckoutButtons';
+import {
+  ApplePayLabel,
+  ApplePayStyle,
+} from './components/AcceleratedCheckoutButtons';
 import type {
   AcceleratedCheckoutButtonsProps,
   RenderStateChangeEvent,
@@ -515,6 +518,7 @@ export {
   AcceleratedCheckoutWallet,
   ApplePayContactField,
   ApplePayLabel,
+  ApplePayStyle,
   ColorScheme,
   ShopifyCheckoutSheet,
   ShopifyCheckoutSheetProvider,

--- a/sample/ios/ReactNativeTests/AcceleratedCheckouts_SupportedTests.swift
+++ b/sample/ios/ReactNativeTests/AcceleratedCheckouts_SupportedTests.swift
@@ -395,6 +395,15 @@ class AcceleratedCheckouts_SupportedTests: XCTestCase {
         XCTAssertTrue(PayWithApplePayButtonLabel.from("unknown", fallback: .buy) == .buy)
     }
 
+    func testApplePayStyleMapping_knownAndUnknownKeys() throws {
+        XCTAssertEqual(PayWithApplePayButtonStyle.from("automatic"), .automatic)
+        XCTAssertEqual(PayWithApplePayButtonStyle.from("black"), .black)
+        XCTAssertEqual(PayWithApplePayButtonStyle.from("white"), .white)
+        XCTAssertEqual(PayWithApplePayButtonStyle.from("whiteOutline"), .whiteOutline)
+        XCTAssertNil(PayWithApplePayButtonStyle.from("unknown"))
+        XCTAssertNil(PayWithApplePayButtonStyle.from(nil))
+    }
+
     func testConfigureAcceleratedCheckoutsResolvesFalseForInvalidApplePayContactField() throws {
         let expectation = self.expectation(description: "configureAcceleratedCheckouts invalid contact field resolves false")
         var resolved: Bool = true

--- a/sample/src/screens/CartScreen.tsx
+++ b/sample/src/screens/CartScreen.tsx
@@ -39,6 +39,7 @@ import {
   useShopifyCheckoutSheet,
   AcceleratedCheckoutButtons,
   ApplePayLabel,
+  ApplePayStyle,
   AcceleratedCheckoutWallet,
 } from '@shopify/checkout-sheet-kit';
 import useShopify from '../hooks/useShopify';
@@ -167,6 +168,7 @@ function CartScreen(): React.JSX.Element {
               <AcceleratedCheckoutButtons
                 {...eventHandlers}
                 applePayLabel={ApplePayLabel.checkout}
+                applePayStyle={ApplePayStyle.black}
                 cartId={cartId}
                 wallets={[
                   AcceleratedCheckoutWallet.applePay,


### PR DESCRIPTION
### What changes are you making?

Adds a new `applePayStyle` prop to `AcceleratedCheckoutButtons` that allows customizing the Apple Pay button appearance. This addresses #443 where consumers couldn't control the button style — for example, getting a white button when a black one was needed for their app's UI.

The prop maps to Apple's `PayWithApplePayButtonStyle` and supports four values: `automatic`, `black`, `white`, and `whiteOutline`. Defaults to `automatic` (adapts to the system light/dark mode).

#### Integration guide

```diff
 <AcceleratedCheckoutButtons
   applePayLabel={ApplePayLabel.checkout}
+  applePayStyle={ApplePayStyle.black}
   cartId={cartId}
   wallets={[
     AcceleratedCheckoutWallet.applePay,
     AcceleratedCheckoutWallet.shopPay,
   ]}
   cornerRadius={cornerRadius}
 />
```

#### Manual Testing

- [ ] `applePayStyle={ApplePayStyle.black}` renders a black Apple Pay button
- [ ] `applePayStyle={ApplePayStyle.white}` renders a white Apple Pay button
- [ ] `applePayStyle={ApplePayStyle.whiteOutline}` renders a white button with outline
- [ ] `applePayStyle={ApplePayStyle.automatic}` adapts to system color scheme
- [ ] Omitting `applePayStyle` defaults to `automatic` behavior
- [ ] Existing props (`applePayLabel`, `cornerRadius`, `wallets`) continue to work alongside `applePayStyle`

---

### PR Checklist

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
