### PR TITLE
feat: bump ShopifyCheckoutSheetKit dependency to 3.7.0

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/RNShopifyCheckoutSheetKit.podspec
+++ b/modules/@shopify/checkout-sheet-kit/RNShopifyCheckoutSheetKit.podspec
@@ -20,8 +20,8 @@ Pod::Spec.new do |s|
   s.source_files = "ios/*.{h,m,mm,swift}"
 
 	s.dependency "React-Core"
-	s.dependency "ShopifyCheckoutSheetKit", "~> 3.6.0"
-	s.dependency "ShopifyCheckoutSheetKit/AcceleratedCheckouts", "~> 3.6.0"
+	s.dependency "ShopifyCheckoutSheetKit", "~> 3.7.0"
+	s.dependency "ShopifyCheckoutSheetKit/AcceleratedCheckouts", "~> 3.7.0"
 
   if fabric_enabled
 		# Use React Native's helper if available, otherwise add dependencies directly

--- a/modules/@shopify/checkout-sheet-kit/package.json
+++ b/modules/@shopify/checkout-sheet-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-sheet-kit",
   "license": "MIT",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "main": "lib/commonjs/index.js",
   "types": "src/index.ts",
   "source": "src/index.ts",

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -2578,7 +2578,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNShopifyCheckoutSheetKit (3.6.0):
+  - RNShopifyCheckoutSheetKit (3.7.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2605,8 +2605,8 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - ShopifyCheckoutSheetKit (~> 3.6.0)
-    - ShopifyCheckoutSheetKit/AcceleratedCheckouts (~> 3.6.0)
+    - ShopifyCheckoutSheetKit (~> 3.7.0)
+    - ShopifyCheckoutSheetKit/AcceleratedCheckouts (~> 3.7.0)
     - SocketRocket
     - Yoga
   - RNVectorIcons (10.3.0):
@@ -2638,11 +2638,11 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ShopifyCheckoutSheetKit (3.6.0):
-    - ShopifyCheckoutSheetKit/Core (= 3.6.0)
-  - ShopifyCheckoutSheetKit/AcceleratedCheckouts (3.6.0):
+  - ShopifyCheckoutSheetKit (3.7.0):
+    - ShopifyCheckoutSheetKit/Core (= 3.7.0)
+  - ShopifyCheckoutSheetKit/AcceleratedCheckouts (3.7.0):
     - ShopifyCheckoutSheetKit/Core
-  - ShopifyCheckoutSheetKit/Core (3.6.0)
+  - ShopifyCheckoutSheetKit/Core (3.7.0)
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
@@ -2996,9 +2996,9 @@ SPEC CHECKSUMS:
   RNGestureHandler: eeb622199ef1fb3a076243131095df1c797072f0
   RNReanimated: 288616f9c66ff4b0911f3862ffcf4104482a2adc
   RNScreens: 3fc29af06302e1f1c18a7829fe57cbc2c0259912
-  RNShopifyCheckoutSheetKit: 47613bb3e98558dd948215b1e3e7c78bee1b3619
+  RNShopifyCheckoutSheetKit: 979ca69f1abbd0b38c3e996879e77a5b42a0103a
   RNVectorIcons: be4d047a76ad307ffe54732208fb0498fcb8477f
-  ShopifyCheckoutSheetKit: e307ac7adc4af43ac4d041922b2073641462cd04
+  ShopifyCheckoutSheetKit: 5bdc6c6c0dafc5ef15daa5963c03547bf6bfff6a
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: a742cc68e8366fcfc681808162492bc0aa7a9498
 


### PR DESCRIPTION
### What changes are you making?

3.7.0 brings us up to storefront api 2025-10
From the PR https://github.com/Shopify/checkout-sheet-kit-swift/pull/554
```
Bump apiVersion to 2025-10
Add cartDeliveryAddressesReplace mutation (new in 2025-10)
Refactor upsertShippingAddress to use cartDeliveryAddressesReplace instead of the remove+add workaround
Remove shouldReapplyShippingMethod and reapplySelectedShippingMethod (no longer needed - replace preserves the shipping method)
Update tests for new mutation
```

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
