### PR TITLE
feat!: bump to v4.0.0 (New Architecture Release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ which enables developers to delivery best-in-class iOS and Android commerce
 experiences.
 
 - [Platform Requirements](#platform-requirements)
+- [Version Compatibility](#version-compatibility)
 - [Getting Started](#getting-started)
   - [1. Installation](#1-installation)
   - [2. Minimum Android requirements](#2-minimum-android-requirements)
@@ -64,9 +65,23 @@ experiences.
 
 ## Platform Requirements
 
-- **React Native** - Minimum version `0.70`
+- **React Native** - Minimum version `0.76` (v4+) / `0.70` (v3 and earlier)
 - **iOS** - Minimum version iOS 13
 - **Android** - Minimum Java 11 & Android SDK version `23`
+
+## Version Compatibility
+
+Starting with **v4.0.0**, `@shopify/checkout-sheet-kit` requires the React Native
+**New Architecture** (TurboModules + Fabric). Apps on the old architecture must
+stay on the `v3.x` line until they migrate.
+
+| Package version | React Native   | Architecture       |
+| --------------- | -------------- | ------------------ |
+| `4.x`           | `>= 0.76`      | New Architecture   |
+| `3.x`           | `>= 0.70`      | Old Architecture   |
+
+See the [React Native upgrade guide](https://reactnative.dev/docs/the-new-architecture/use-the-new-architecture)
+for help enabling the New Architecture in your app.
 
 ## Getting Started
 

--- a/dev.yml
+++ b/dev.yml
@@ -10,7 +10,7 @@ up:
       - sccache
   - ruby
   - xcode:
-      version: "26.2"
+      version: '26.2'
       runtimes:
         ios:
           - version: 23C54 # 26.2

--- a/modules/@shopify/checkout-sheet-kit/package.json
+++ b/modules/@shopify/checkout-sheet-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-sheet-kit",
   "license": "MIT",
-  "version": "3.8.0",
+  "version": "4.0.0",
   "main": "lib/commonjs/index.js",
   "types": "src/index.ts",
   "source": "src/index.ts",

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -2578,7 +2578,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNShopifyCheckoutSheetKit (3.8.0):
+  - RNShopifyCheckoutSheetKit (4.0.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2996,7 +2996,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: eeb622199ef1fb3a076243131095df1c797072f0
   RNReanimated: 237d420b7bb4378ef1dacc7d7a5c674fddb4b5d2
   RNScreens: 3fc29af06302e1f1c18a7829fe57cbc2c0259912
-  RNShopifyCheckoutSheetKit: 0da44f403a7176465fd25aa58c6fe9edfc95353b
+  RNShopifyCheckoutSheetKit: 2a8c97d7780466538843d4cb1368c7ed76a33689
   RNVectorIcons: be4d047a76ad307ffe54732208fb0498fcb8477f
   ShopifyCheckoutSheetKit: 5253ca4da4c4f31069286509693930d02b4150d8
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748


### PR DESCRIPTION
## v4.0.0 — React Native New Architecture

v4 is a breaking release. The library now requires the React Native
**New Architecture** (TurboModules + Fabric) and no longer supports the
legacy bridge. Apps that are still on the old architecture should stay
on the `3.x` line.

## Changelog

### Breaking changes

**New Architecture is now required.**
- Consumers must have `newArchEnabled=true` on Android and
  `:new_arch_enabled => true` in the iOS `Podfile`.
- See the React Native upgrade guide for migration help:
  https://reactnative.dev/docs/the-new-architecture/use-the-new-architecture

**Several promise-returning APIs are now synchronous.** Drop `await`
from call sites:

| API | Before | After |
|-----|--------|-------|
| `getConfig()` | `Promise<Configuration>` | `Configuration` |
| `setConfig(config)` | `Promise<void>` | `void` |
| `configureAcceleratedCheckouts(config)` | `Promise<boolean>` | `boolean` |
| `isAcceleratedCheckoutAvailable()` | `Promise<boolean>` | `boolean` |
| `isApplePayAvailable()` | `Promise<boolean>` | `boolean` |

```diff
- const config = await shopify.getConfig();
+ const config = shopify.getConfig();

- await shopify.setConfig({preloading: true});
+ shopify.setConfig({preloading: true});

- const available = await shopify.isAcceleratedCheckoutAvailable();
+ const available = shopify.isAcceleratedCheckoutAvailable();
```

### Under the hood

- Native modules migrated from legacy bridge (`RCT_EXTERN_MODULE` / `ReactPackage`) to TurboModules (`NativeShopifyCheckoutSheetKitSpecBase` on iOS, `TurboReactPackage` on Android).
- Old-architecture conditional code paths removed from `RNShopifyCheckoutSheetKit.podspec` and Android `build.gradle`.
- `AcceleratedCheckoutButtons` now registered via `codegenNativeComponent`.
- Added runtime coercion for `colorScheme` / `logLevel` values returned by `getConfig()` — unknown values from native now fall back to safe defaults (`automatic` / `error`) rather than silently passing through as untyped strings.

### Migration checklist

- [ ] Enable New Architecture in your app (see React Native docs)
- [ ] Remove `await` from the five APIs listed above
- [ ] Reinstall pods: `cd ios && bundle exec pod install`