### PR TITLE
Add Dependabot cooldown to delay version bump PRs by 7 days

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,12 +5,16 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
 
   # Root package.json (monorepo dependencies)
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types:
@@ -22,6 +26,8 @@ updates:
     directory: "/modules/@shopify/checkout-sheet-kit"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types:
@@ -33,6 +39,8 @@ updates:
     directory: "/sample"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types:
@@ -43,6 +51,8 @@ updates:
     directory: "/sample"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types:
@@ -54,6 +64,8 @@ updates:
     directory: "/sample/android"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types:
@@ -64,6 +76,8 @@ updates:
     directory: "/modules/@shopify/checkout-sheet-kit/android"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types:


### PR DESCRIPTION
Adds a 7-day cooldown to all Dependabot update blocks via the `cooldown.default-days` setting. New releases will only be proposed as update PRs once they have been published for at least 7 days.

This gives time for problematic releases (including supply-chain compromises) to be identified and yanked before we pick them up.

Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-

Requested by Daniel Kift <daniel.kift@shopify.com>

### What changes are you making?

<!-- Please describe why you are making these changes -->

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
