### PR TITLE
fix: migrate android to use sccache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ cargo install sccache
 # Other systems: see https://github.com/mozilla/sccache#installation
 ```
 
-The build scripts will automatically detect and use sccache if available. If you encounter any build issues, you can temporarily disable it:
+The build scripts will automatically detect and use sccache if available. On Android, React Native's CMake files look for a command named `ccache`, so the sample Android scripts put an sccache-backed compatibility command first on `PATH`. If you encounter any build issues, you can temporarily disable it:
 
 ```sh
 # Disable sccache for a single build

--- a/sample/package.json
+++ b/sample/package.json
@@ -3,7 +3,7 @@
   "version": "0.6.0",
   "private": true,
   "scripts": {
-    "android": "react-native run-android",
+    "android": "sh ./scripts/android",
     "clean": "rm -rf node_modules ios/build ios/pods vendor",
     "clean:android": "(cd android && ./gradlew clean)",
     "build:android": "sh ./scripts/build_android",

--- a/sample/scripts/android
+++ b/sample/scripts/android
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/android_sccache"
+
+exec react-native run-android "$@"

--- a/sample/scripts/android_sccache
+++ b/sample/scripts/android_sccache
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+
+# React Native's Android CMake files discover and invoke a command named
+# `ccache`. Put an sccache-backed compatibility command first on PATH.
+if [ "${SCCACHE:-}" = "false" ]; then
+  if command -v sccache >/dev/null 2>&1; then
+    sccache --stop-server 2>/dev/null || true
+  fi
+  return 0 2>/dev/null || exit 0
+fi
+
+if command -v sccache >/dev/null 2>&1; then
+  ANDROID_SCCACHE_SHIM_DIR="${TMPDIR:-/tmp}/checkout-sheet-kit-react-native-sccache"
+  mkdir -p "$ANDROID_SCCACHE_SHIM_DIR"
+  cat > "$ANDROID_SCCACHE_SHIM_DIR/ccache" <<'EOF'
+#!/usr/bin/env sh
+exec sccache "$@"
+EOF
+  chmod +x "$ANDROID_SCCACHE_SHIM_DIR/ccache"
+  export PATH="$ANDROID_SCCACHE_SHIM_DIR:$PATH"
+  export RUSTC_WRAPPER="${RUSTC_WRAPPER:-sccache}"
+fi

--- a/sample/scripts/build_android
+++ b/sample/scripts/build_android
@@ -1,6 +1,9 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -ex
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/android_sccache"
 
 cd android
 

--- a/sample/scripts/release_android
+++ b/sample/scripts/release_android
@@ -1,9 +1,12 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # Working directory is "sample" when running "pnpm sample release:android" from root.
 
 # Exit immediately if a command exits with a non-zero status
 set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/android_sccache"
 
 # Print each command as it is executed
 set -x

--- a/sample/scripts/test_android
+++ b/sample/scripts/test_android
@@ -2,6 +2,9 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/android_sccache"
+
 cd android
 
 ./gradlew clean generateAndroidManifestFromTemplate test --no-daemon --console=plain -Dorg.gradle.workers.max=1 -PreactNativeArchitectures=arm64-v8a


### PR DESCRIPTION
### What changes are you making?

<!-- Please describe why you are making these changes -->

---

### PR Checklist

> [!IMPORTANT]
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.