### PR TITLE
Manually complete fast-xml-parser 4.5.3 → 4.5.6 bump

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2573,8 +2573,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-xml-parser@4.5.3:
-    resolution: {integrity: sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==}
+  fast-xml-parser@4.5.6:
+    resolution: {integrity: sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==}
     hasBin: true
 
   fastq@1.15.0:
@@ -6128,7 +6128,7 @@ snapshots:
       '@react-native-community/cli-tools': 19.1.1
       chalk: 4.1.2
       fast-glob: 3.3.3
-      fast-xml-parser: 4.5.3
+      fast-xml-parser: 4.5.6
 
   '@react-native-community/cli-config-apple@19.1.1':
     dependencies:
@@ -6182,7 +6182,7 @@ snapshots:
       '@react-native-community/cli-tools': 19.1.1
       chalk: 4.1.2
       execa: 5.1.1
-      fast-xml-parser: 4.5.3
+      fast-xml-parser: 4.5.6
 
   '@react-native-community/cli-platform-ios@19.1.1':
     dependencies:
@@ -7795,7 +7795,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-xml-parser@4.5.3:
+  fast-xml-parser@4.5.6:
     dependencies:
       strnum: 1.1.2
 


### PR DESCRIPTION
## Why

Dependabot PR #462 was titled as a fast-xml-parser bump (4.5.3 → 4.5.6) and merged green, but inspection of the merged commit (86fb324) shows the patch did not actually update fast-xml-parser in `pnpm-lock.yaml` — only unrelated transitive deps (`@babel/parser`, `@jridgewell/trace-mapping`, `debug`, `jsesc`) moved. All four `fast-xml-parser@4.5.3` references remained on `main` post-merge.

This appears related to bumperbot bug [Shopify/infrasec-bumper#673](https://github.com/Shopify/infrasec-bumper/issues/673) — "Bumper handle nested manifests correctly". The infrasec deep-dive (Mar 11, Rune Madsen) flagged the same class of issue with fast-xml-parser specifically.

## What

Reproduces the bump dependabot intended, by running:

```
pnpm update fast-xml-parser --lockfile-only --recursive
```

Result: 5 insertions / 5 deletions in `pnpm-lock.yaml`, all four references updated to 4.5.6 (package definitions + snapshot entries for `@react-native-community/cli-platform-android@19.1.1` and `cli-platform-ios@19.1.1`). No `package.json` change — fast-xml-parser is purely transitive here.

## Context

This unblocks the `multirepo-denylist-check` failure on [shopify-playground/checkout-kit#31](https://github.com/shopify-playground/checkout-kit/pull/31), which imports this lockfile verbatim under `react-native/`. Once this merges, that import PR will be re-synced from the new source `main` and the denylist check should clear.

cc @kieran-osgood-shopify @markmur @danielkift