### PR TITLE
Release 3.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Select Xcode 26.2
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+          xcrun xcodebuild -version
+
       - name: Display Current Xcode Information
         run: |
           echo "Xcode Path: $(xcode-select -p)"

--- a/modules/@shopify/checkout-sheet-kit/RNShopifyCheckoutSheetKit.podspec
+++ b/modules/@shopify/checkout-sheet-kit/RNShopifyCheckoutSheetKit.podspec
@@ -20,8 +20,8 @@ Pod::Spec.new do |s|
   s.source_files = "ios/*.{h,m,mm,swift}"
 
 	s.dependency "React-Core"
-	s.dependency "ShopifyCheckoutSheetKit", "~> 3.8.0"
-	s.dependency "ShopifyCheckoutSheetKit/AcceleratedCheckouts", "~> 3.8.0"
+	s.dependency "ShopifyCheckoutSheetKit", "= 3.8.1"
+	s.dependency "ShopifyCheckoutSheetKit/AcceleratedCheckouts", "= 3.8.1"
 
   if fabric_enabled
 		# Use React Native's helper if available, otherwise add dependencies directly

--- a/modules/@shopify/checkout-sheet-kit/package.json
+++ b/modules/@shopify/checkout-sheet-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-sheet-kit",
   "license": "MIT",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "main": "lib/commonjs/index.js",
   "types": "src/index.ts",
   "source": "src/index.ts",

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -2578,7 +2578,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNShopifyCheckoutSheetKit (3.8.0):
+  - RNShopifyCheckoutSheetKit (3.8.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2605,8 +2605,8 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - ShopifyCheckoutSheetKit (~> 3.8.0)
-    - ShopifyCheckoutSheetKit/AcceleratedCheckouts (~> 3.8.0)
+    - ShopifyCheckoutSheetKit (= 3.8.1)
+    - ShopifyCheckoutSheetKit/AcceleratedCheckouts (= 3.8.1)
     - SocketRocket
     - Yoga
   - RNVectorIcons (10.3.0):
@@ -2638,11 +2638,11 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ShopifyCheckoutSheetKit (3.8.0):
-    - ShopifyCheckoutSheetKit/Core (= 3.8.0)
-  - ShopifyCheckoutSheetKit/AcceleratedCheckouts (3.8.0):
+  - ShopifyCheckoutSheetKit (3.8.1):
+    - ShopifyCheckoutSheetKit/Core (= 3.8.1)
+  - ShopifyCheckoutSheetKit/AcceleratedCheckouts (3.8.1):
     - ShopifyCheckoutSheetKit/Core
-  - ShopifyCheckoutSheetKit/Core (3.8.0)
+  - ShopifyCheckoutSheetKit/Core (3.8.1)
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
@@ -2996,9 +2996,9 @@ SPEC CHECKSUMS:
   RNGestureHandler: eeb622199ef1fb3a076243131095df1c797072f0
   RNReanimated: 288616f9c66ff4b0911f3862ffcf4104482a2adc
   RNScreens: 3fc29af06302e1f1c18a7829fe57cbc2c0259912
-  RNShopifyCheckoutSheetKit: 5587e0fc360607d832f7f10f8436883d1db4b5ef
+  RNShopifyCheckoutSheetKit: 55c669c863d50711ea32bc42d89bf92a8e2aad7f
   RNVectorIcons: be4d047a76ad307ffe54732208fb0498fcb8477f
-  ShopifyCheckoutSheetKit: 5253ca4da4c4f31069286509693930d02b4150d8
+  ShopifyCheckoutSheetKit: f3bddd39ab853667aaae0fa324eec301ff1c751a
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: a742cc68e8366fcfc681808162492bc0aa7a9498
 


### PR DESCRIPTION
## Summary

Bumps the React Native package to 3.8.1 and pins the iOS Shopify Checkout Sheet Kit SDK to 3.8.1 for the 3.8.x patch release.

ShopifyCheckoutSheetKitSwift 3.8.1 includes important bug fixes:
https://github.com/Shopify/checkout-sheet-kit-swift/releases/tag/3.8.1
- [AC] Fix Apple Pay crash - Equatable SwiftUI PassKit symbols by @kieran-osgood-shopify in https://github.com/Shopify/checkout-sheet-kit-swift/pull/574
- Fix Crash: WebPixel.CustomData parsing null/nested arrays by @kieran-osgood-shopify in https://github.com/Shopify/checkout-sheet-kit-swift/pull/575

This PR targets `release-3.8.0-base`, a temporary branch at the `3.8.0` tag, so the diff only shows the 3.8.1 patch.

## Testing

- [x] `bundle exec pod install --deployment` from `sample/ios`
- [x] `yarn test` — 121 tests passed
- [x] `SCCACHE=false CURRENT_SIMULATOR_UUID=48B8B315-0429-4EB2-A482-F5223CBD96D7 yarn sample build:ios` — build succeeded
- [x] `SCCACHE=false CURRENT_SIMULATOR_UUID=48B8B315-0429-4EB2-A482-F5223CBD96D7 yarn sample test:ios` — 53 native iOS tests passed on iOS 26.2
- [x] `git diff --check`

## Notes

`/opt/dev/bin/dev check` passes `lint_module` and `lint_sample`, but `lint_swift` reports an existing SwiftFormat `docComments` issue in `AcceleratedCheckoutButtons.swift` lines 165-166. This patch does not touch that file.
