### PR TITLE
Pin CI Xcode to 26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Select Xcode 26.2
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+          xcrun xcodebuild -version
+
       - name: Display Current Xcode Information
         run: |
           echo "Xcode Path: $(xcode-select -p)"


### PR DESCRIPTION
## Summary

Main was failing CI because macos latest defaults to xcode 26.5 which we haven't started to support just yet
Select Xcode 26.2 explicitly in the Swift test job
Keep CI aligned with dev.yml and avoid runner image default Xcode drift
