### PR TITLE
Bump Android Checkout Sheet Kit to 3.6.0

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/android/gradle.properties
+++ b/modules/@shopify/checkout-sheet-kit/android/gradle.properties
@@ -5,4 +5,4 @@ ndkVersion=23.1.7779620
 buildToolsVersion = "35.0.0"
 
 # Version of Shopify Checkout SDK to use with React Native
-SHOPIFY_CHECKOUT_SDK_VERSION=3.5.3
+SHOPIFY_CHECKOUT_SDK_VERSION=3.6.0

--- a/sample/android/gradle.properties
+++ b/sample/android/gradle.properties
@@ -39,4 +39,4 @@ hermesEnabled=true
 newArchEnabled=true
 
 # Note: only used here for testing
-SHOPIFY_CHECKOUT_SDK_VERSION=3.5.3
+SHOPIFY_CHECKOUT_SDK_VERSION=3.6.0


### PR DESCRIPTION
### What changes are you making?

Bumps the Android Shopify Checkout SDK version from `3.5.3` to `3.6.0` in both the module and sample app.

### PR Checklist

> [!IMPORTANT]
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.