### PR TITLE
Bump Android Checkout Sheet Kit to 3.6.1

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/android/gradle.properties
+++ b/modules/@shopify/checkout-sheet-kit/android/gradle.properties
@@ -5,4 +5,4 @@ ndkVersion=23.1.7779620
 buildToolsVersion = "35.0.0"
 
 # Version of Shopify Checkout SDK to use with React Native
-SHOPIFY_CHECKOUT_SDK_VERSION=3.6.0
+SHOPIFY_CHECKOUT_SDK_VERSION=3.6.1

--- a/modules/@shopify/checkout-sheet-kit/package.json
+++ b/modules/@shopify/checkout-sheet-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-sheet-kit",
   "license": "MIT",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "main": "lib/commonjs/index.js",
   "types": "src/index.ts",
   "source": "src/index.ts",

--- a/sample/android/gradle.properties
+++ b/sample/android/gradle.properties
@@ -41,4 +41,4 @@ newArchEnabled=true
 hermesEnabled=true
 
 # Note: only used here for testing
-SHOPIFY_CHECKOUT_SDK_VERSION=3.6.0
+SHOPIFY_CHECKOUT_SDK_VERSION=3.6.1

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -2578,7 +2578,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNShopifyCheckoutSheetKit (3.8.2):
+  - RNShopifyCheckoutSheetKit (3.8.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2996,7 +2996,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: eeb622199ef1fb3a076243131095df1c797072f0
   RNReanimated: 288616f9c66ff4b0911f3862ffcf4104482a2adc
   RNScreens: 3fc29af06302e1f1c18a7829fe57cbc2c0259912
-  RNShopifyCheckoutSheetKit: 2952e5d92b95961ad9d0d970b64a8fcba02eca19
+  RNShopifyCheckoutSheetKit: 8f056ea8ef7fc8116a83c969bf6c024ce49d2dae
   RNVectorIcons: be4d047a76ad307ffe54732208fb0498fcb8477f
   ShopifyCheckoutSheetKit: f3bddd39ab853667aaae0fa324eec301ff1c751a
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748


### PR DESCRIPTION
Assisted-By: devx/65cbbc4b-e5c5-42bf-8788-70c6aa58a8e8

### What changes are you making?

Bump to 3.6.1 to undo an unexpected bump to the kotlin stdlib

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
