### PR TITLE
Fix accelerated checkout button hit area

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/src/components/AcceleratedCheckoutButtons.tsx
+++ b/modules/@shopify/checkout-sheet-kit/src/components/AcceleratedCheckoutButtons.tsx
@@ -178,8 +178,6 @@ export type AcceleratedCheckoutButtonsProps = (CartProps | VariantProps) &
  * />
  */
 
-const defaultStyles = {flex: 1};
-
 export const AcceleratedCheckoutButtons: React.FC<
   AcceleratedCheckoutButtonsProps
 > = ({
@@ -306,7 +304,7 @@ export const AcceleratedCheckoutButtons: React.FC<
       testID="accelerated-checkout-buttons"
       applePayLabel={applePayLabel}
       applePayStyle={applePayStyle}
-      style={{...defaultStyles, height: dynamicHeight}}
+      style={dynamicHeight ? {height: dynamicHeight} : undefined}
       checkoutIdentifier={checkoutIdentifier}
       cornerRadius={cornerRadius}
       wallets={wallets}

--- a/modules/@shopify/checkout-sheet-kit/tests/AcceleratedCheckoutButtons.test.tsx
+++ b/modules/@shopify/checkout-sheet-kit/tests/AcceleratedCheckoutButtons.test.tsx
@@ -290,19 +290,18 @@ describe('AcceleratedCheckoutButtons', () => {
       expect(onClickLink).not.toHaveBeenCalled();
     });
 
-    it('applies dynamic height when onSizeChange is emitted', async () => {
+    it('applies only the dynamic height when onSizeChange is emitted', async () => {
       const {getByTestId} = render(
         <AcceleratedCheckoutButtons cartId="gid://shopify/Cart/123" />,
       );
       let nativeComponent = getByTestId('accelerated-checkout-buttons');
+      expect(nativeComponent.props.style).toBeUndefined();
+
       await act(async () => {
         nativeComponent.props.onSizeChange({nativeEvent: {height: 42}});
       });
       nativeComponent = getByTestId('accelerated-checkout-buttons');
-      expect(nativeComponent.props.style).toEqual({
-        flex: 1,
-        height: 42,
-      });
+      expect(nativeComponent.props.style).toEqual({height: 42});
     });
 
     it('warns and returns null when missing identifiers in production', () => {


### PR DESCRIPTION
## Summary

- remove the default `flex: 1` style from `AcceleratedCheckoutButtons` so the native `onSizeChange` height participates in Yoga layout
- leave the native component unstyled until it reports a height, then apply only that height
- update the regression test to ensure flex sizing cannot override the reported height again

## Reproduction

Reproduced with Checkout Sheet Kit 3.8.1, Expo SDK 57, React Native 0.86.0, and an iOS 18 simulator. With two wallets, native reported 104 pt while the React Native frame remained 48 pt; taps on the visibly overflowing button edges were dropped. Removing `flex: 1` made the React Native frame match the reported height.

Fixes #502