### PR TITLE
Add clickLink event for intercepting checkout link clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ experiences.
 - [Checkout lifecycle](#checkout-lifecycle)
   - [`addEventListener(eventName, callback)`](#addeventlistenereventname-callback)
   - [`removeEventListeners(eventName)`](#removeeventlistenerseventname)
+  - [Intercepting clicked links](#intercepting-clicked-links)
 - [Behavioral data - Web pixels](#behavioral-data---web-pixels)
 - [Identity \& customer accounts](#identity--customer-accounts)
   - [Cart: buyer bag, identity, and preferences](#cart-buyer-bag-identity-and-preferences)
@@ -594,9 +595,9 @@ Should you wish to manually clear the preload cache, there is a `ShopifyCheckout
 
 ## Checkout lifecycle
 
-There are currently 3 checkout events exposed through the Native Module. You can
-subscribe to these events using `addEventListener` and `removeEventListeners`
-methods - available on both the context provider as well as the class instance.
+You can subscribe to checkout events using the `addEventListener` and
+`removeEventListeners` methods - available on both the context provider as well
+as the class instance.
 
 | Name        | Callback                                  | Description                                                  |
 | ----------- | ----------------------------------------- | ------------------------------------------------------------ |
@@ -604,6 +605,7 @@ methods - available on both the context provider as well as the class instance.
 | `completed` | `(event: CheckoutCompletedEvent) => void` | Fired when the checkout has been successfully completed.     |
 | `error`     | `(error: {message: string}) => void`      | Fired when a checkout exception has been raised.             |
 | `pixel`     | `(event: PixelEvent) => void`             | Fired when a Web Pixel event has been relayed from checkout. |
+| `clickLink` | `(event: ClickLinkEvent) => void`         | Fired when a link is clicked that would be opened outside of checkout. See [Intercepting clicked links](#intercepting-clicked-links). |
 
 ### `addEventListener(eventName, callback)`
 
@@ -660,6 +662,36 @@ useEffect(() => {
 
 On the rare occasion that you want to remove all event listeners for a given
 `eventName`, you can use the `removeEventListeners(eventName)` method.
+
+### Intercepting clicked links
+
+By default, links clicked within checkout that would be opened outside of it
+are handed to the operating system. Subscribe to the `clickLink` event to
+handle these links yourself instead:
+
+```tsx
+const shopifyCheckout = useShopifyCheckoutSheet();
+
+useEffect(() => {
+  const clickLink = shopifyCheckout.addEventListener(
+    'clickLink',
+    (event: ClickLinkEvent) => {
+      // Handle event.url
+    },
+  );
+
+  return () => {
+    clickLink?.remove();
+  };
+}, [shopifyCheckout]);
+```
+
+> [!IMPORTANT]
+> While at least one `clickLink` listener is attached, the SDK's default link
+> handling is disabled - your app is responsible for every clicked link. Fall
+> back to `Linking.openURL(event.url)` for any URL you don't handle
+> explicitly. Once the last listener is removed, the default behavior is
+> restored.
 
 ## Behavioral data - Web pixels
 

--- a/__mocks__/react-native.ts
+++ b/__mocks__/react-native.ts
@@ -59,6 +59,7 @@ const ShopifyCheckoutSheetKit = {
   addEventListener: jest.fn(),
   removeEventListeners: jest.fn(),
   initiateGeolocationRequest: jest.fn(),
+  setClickLinkInterceptionEnabled: jest.fn(),
   configureAcceleratedCheckouts: jest.fn(() => true),
   isAcceleratedCheckoutAvailable: jest.fn(() => true),
   isApplePayAvailable: jest.fn(() => true),

--- a/modules/@shopify/checkout-sheet-kit/android/gradle.properties
+++ b/modules/@shopify/checkout-sheet-kit/android/gradle.properties
@@ -5,4 +5,4 @@ ndkVersion=23.1.7779620
 buildToolsVersion = "35.0.0"
 
 # Version of Shopify Checkout SDK to use with React Native
-SHOPIFY_CHECKOUT_SDK_VERSION=3.6.0
+SHOPIFY_CHECKOUT_SDK_VERSION=3.6.1

--- a/modules/@shopify/checkout-sheet-kit/android/src/main/java/com/shopify/reactnative/checkoutsheetkit/CustomCheckoutEventProcessor.java
+++ b/modules/@shopify/checkout-sheet-kit/android/src/main/java/com/shopify/reactnative/checkoutsheetkit/CustomCheckoutEventProcessor.java
@@ -24,6 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 package com.shopify.reactnative.checkoutsheetkit;
 
 import android.content.Context;
+import android.net.Uri;
 import android.util.Log;
 import android.webkit.GeolocationPermissions;
 
@@ -42,7 +43,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class CustomCheckoutEventProcessor extends DefaultCheckoutEventProcessor {
+
+  /**
+   * java.util.function.Supplier requires API 24; this module's minSdk is 23.
+   */
+  interface BooleanSupplier {
+    boolean get();
+  }
+
   private final ReactApplicationContext reactContext;
+  private final BooleanSupplier clickLinkInterceptionEnabled;
   private final ObjectMapper mapper = new ObjectMapper();
 
   // Geolocation-specific variables
@@ -51,8 +61,16 @@ public class CustomCheckoutEventProcessor extends DefaultCheckoutEventProcessor 
   private GeolocationPermissions.Callback geolocationCallback;
 
   public CustomCheckoutEventProcessor(Context context, ReactApplicationContext reactContext) {
+    this(context, reactContext, () -> false);
+  }
+
+  public CustomCheckoutEventProcessor(
+      Context context,
+      ReactApplicationContext reactContext,
+      BooleanSupplier clickLinkInterceptionEnabled) {
     super(context);
     this.reactContext = reactContext;
+    this.clickLinkInterceptionEnabled = clickLinkInterceptionEnabled;
   }
 
   // Public methods
@@ -130,6 +148,19 @@ public class CustomCheckoutEventProcessor extends DefaultCheckoutEventProcessor 
   @Override
   public void onCheckoutCanceled() {
     sendEvent("close", null);
+  }
+
+  @Override
+  public void onCheckoutLinkClicked(@NonNull Uri uri) {
+    if (clickLinkInterceptionEnabled.get()) {
+      WritableNativeMap params = new WritableNativeMap();
+      params.putString("url", uri.toString());
+      sendEvent("clickLink", params);
+    } else {
+      // No JS listener owns links right now — preserve the kit's default
+      // behavior (ACTION_VIEW / mailto / tel handling).
+      super.onCheckoutLinkClicked(uri);
+    }
   }
 
   @Override

--- a/modules/@shopify/checkout-sheet-kit/android/src/main/java/com/shopify/reactnative/checkoutsheetkit/ShopifyCheckoutSheetKitModule.java
+++ b/modules/@shopify/checkout-sheet-kit/android/src/main/java/com/shopify/reactnative/checkoutsheetkit/ShopifyCheckoutSheetKitModule.java
@@ -51,6 +51,10 @@ public class ShopifyCheckoutSheetKitModule extends NativeShopifyCheckoutSheetKit
 
   private CustomCheckoutEventProcessor checkoutEventProcessor;
 
+  // Written from the JS thread, read from the main thread when a checkout link
+  // is clicked, hence volatile.
+  private volatile boolean clickLinkInterceptionEnabled = false;
+
   public ShopifyCheckoutSheetKitModule(ReactApplicationContext reactContext) {
     super(reactContext);
 
@@ -83,7 +87,8 @@ public class ShopifyCheckoutSheetKitModule extends NativeShopifyCheckoutSheetKit
   public void present(String checkoutURL) {
     Activity currentActivity = getCurrentActivity();
     if (currentActivity instanceof ComponentActivity) {
-      checkoutEventProcessor = new CustomCheckoutEventProcessor(currentActivity, this.reactContext);
+      checkoutEventProcessor = new CustomCheckoutEventProcessor(currentActivity, this.reactContext,
+          () -> clickLinkInterceptionEnabled);
       currentActivity.runOnUiThread(() -> {
         checkoutSheet = ShopifyCheckoutSheetKit.present(checkoutURL, (ComponentActivity) currentActivity,
             checkoutEventProcessor);
@@ -196,6 +201,11 @@ public class ShopifyCheckoutSheetKitModule extends NativeShopifyCheckoutSheetKit
     if (checkoutEventProcessor != null) {
       checkoutEventProcessor.invokeGeolocationCallback(allow);
     }
+  }
+
+  @ReactMethod
+  public void setClickLinkInterceptionEnabled(boolean enabled) {
+    clickLinkInterceptionEnabled = enabled;
   }
 
   // Private

--- a/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.swift
+++ b/modules/@shopify/checkout-sheet-kit/ios/ShopifyCheckoutSheetKit.swift
@@ -31,6 +31,7 @@ import UIKit
 @objc(RCTShopifyCheckoutSheetKit)
 class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
     private var hasListeners = false
+    private var clickLinkInterceptionEnabled = false
 
     internal var checkoutSheet: UIViewController?
     private var acceleratedCheckoutsConfiguration: Any?
@@ -54,7 +55,7 @@ class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
     }
 
     override func supportedEvents() -> [String]! {
-        return ["close", "completed", "error", "pixel"]
+        return ["clickLink", "close", "completed", "error", "pixel"]
     }
 
     override func startObserving() {
@@ -84,6 +85,16 @@ class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
     func checkoutDidEmitWebPixelEvent(event: ShopifyCheckoutSheetKit.PixelEvent) {
         if hasListeners {
             sendEvent(withName: "pixel", body: ShopifyEventSerialization.serialize(pixelEvent: event))
+        }
+    }
+
+    func checkoutDidClickLink(url: URL) {
+        if hasListeners, clickLinkInterceptionEnabled {
+            sendEvent(withName: "clickLink", body: ["url": url.absoluteString])
+        } else if UIApplication.shared.canOpenURL(url) {
+            // No JS listener owns links right now — preserve the kit's default
+            // CheckoutDelegate behavior of opening the URL externally.
+            UIApplication.shared.open(url)
         }
     }
 
@@ -294,6 +305,10 @@ class RCTShopifyCheckoutSheetKit: RCTEventEmitter, CheckoutDelegate {
 
     @objc func initiateGeolocationRequest(_ allow: Bool) {
         // No-op on iOS — geolocation permission is handled natively
+    }
+
+    @objc func setClickLinkInterceptionEnabled(_ enabled: Bool) {
+        clickLinkInterceptionEnabled = enabled
     }
 
     // MARK: - Private

--- a/modules/@shopify/checkout-sheet-kit/src/index.d.ts
+++ b/modules/@shopify/checkout-sheet-kit/src/index.d.ts
@@ -172,6 +172,7 @@ export type Configuration = CommonConfiguration & {
   );
 
 export type CheckoutEvent =
+  | 'clickLink'
   | 'close'
   | 'completed'
   | 'error'
@@ -182,7 +183,20 @@ export interface GeolocationRequestEvent {
   origin: string;
 }
 
+/**
+ * Emitted when a link is clicked within the checkout sheet that would
+ * otherwise be opened outside of it (e.g. in the system browser).
+ *
+ * Note: while at least one 'clickLink' listener is attached, the SDK's
+ * default link handling (opening the URL externally) is disabled — the
+ * host app owns every clicked link.
+ */
+export interface ClickLinkEvent {
+  url: string;
+}
+
 export type CloseEventCallback = () => void;
+export type ClickLinkEventCallback = (event: ClickLinkEvent) => void;
 export type GeolocationRequestEventCallback = (
   event: GeolocationRequestEvent,
 ) => void;
@@ -194,6 +208,7 @@ export type CheckoutCompletedEventCallback = (
 
 export type CheckoutEventCallback =
   | CloseEventCallback
+  | ClickLinkEventCallback
   | CheckoutExceptionCallback
   | CheckoutCompletedEventCallback
   | GeolocationRequestEventCallback
@@ -293,6 +308,11 @@ function addEventListener(
 function addEventListener(
   event: 'geolocationRequest',
   callback: GeolocationRequestEventCallback,
+): Maybe<EmitterSubscription>;
+
+function addEventListener(
+  event: 'clickLink',
+  callback: ClickLinkEventCallback,
 ): Maybe<EmitterSubscription>;
 
 function removeEventListeners(event: CheckoutEvent): void;

--- a/modules/@shopify/checkout-sheet-kit/src/index.ts
+++ b/modules/@shopify/checkout-sheet-kit/src/index.ts
@@ -34,6 +34,7 @@ import type {
   AcceleratedCheckoutConfiguration,
   CheckoutEvent,
   CheckoutEventCallback,
+  ClickLinkEvent,
   Configuration,
   Features,
   GeolocationRequestEvent,
@@ -80,6 +81,11 @@ class ShopifyCheckoutSheet implements ShopifyCheckoutSheetKit {
 
   private features: Features;
   private geolocationCallback: Maybe<EventSubscription>;
+
+  // Tracks live 'clickLink' subscriptions so native link interception is only
+  // enabled while at least one listener exists. While enabled, the SDK's
+  // default link handling (opening externally) is suppressed.
+  private clickLinkListenerCount = 0;
 
   private _acceleratedCheckoutsReady = false;
 
@@ -206,12 +212,23 @@ class ShopifyCheckoutSheet implements ShopifyCheckoutSheetKit {
           callback,
         );
         break;
+      case 'clickLink':
+        eventCallback = this.interceptEventEmission('clickLink', callback);
+        break;
       default:
         eventCallback = callback;
     }
 
-    // Default handler for all non-pixel events
-    return ShopifyCheckoutSheet.eventEmitter.addListener(event, eventCallback);
+    const subscription = ShopifyCheckoutSheet.eventEmitter.addListener(
+      event,
+      eventCallback,
+    );
+
+    if (event === 'clickLink') {
+      return this.trackClickLinkSubscription(subscription);
+    }
+
+    return subscription;
   }
 
   /**
@@ -220,6 +237,11 @@ class ShopifyCheckoutSheet implements ShopifyCheckoutSheetKit {
    */
   public removeEventListeners(event: CheckoutEvent) {
     ShopifyCheckoutSheet.eventEmitter.removeAllListeners(event);
+
+    if (event === 'clickLink' && this.clickLinkListenerCount > 0) {
+      this.clickLinkListenerCount = 0;
+      RNShopifyCheckoutSheetKit.setClickLinkInterceptionEnabled(false);
+    }
   }
 
   /**
@@ -286,6 +308,39 @@ class ShopifyCheckoutSheet implements ShopifyCheckoutSheetKit {
   }
 
   // --- private
+
+  /**
+   * Enables native 'clickLink' interception while at least one listener is
+   * attached, and restores the SDK's default link handling once the last
+   * listener is removed.
+   */
+  private trackClickLinkSubscription(
+    subscription: EmitterSubscription,
+  ): EmitterSubscription {
+    this.clickLinkListenerCount += 1;
+    if (this.clickLinkListenerCount === 1) {
+      RNShopifyCheckoutSheetKit.setClickLinkInterceptionEnabled(true);
+    }
+
+    const originalRemove = subscription.remove.bind(subscription);
+    let removed = false;
+    subscription.remove = () => {
+      originalRemove();
+      if (removed) {
+        return;
+      }
+      removed = true;
+      this.clickLinkListenerCount = Math.max(
+        0,
+        this.clickLinkListenerCount - 1,
+      );
+      if (this.clickLinkListenerCount === 0) {
+        RNShopifyCheckoutSheetKit.setClickLinkInterceptionEnabled(false);
+      }
+    };
+
+    return subscription;
+  }
 
   /**
    * Accelerated Checkouts is only supported from iOS 16.0 onwards
@@ -581,6 +636,7 @@ export type {
   CheckoutEvent,
   CheckoutEventCallback,
   CheckoutException,
+  ClickLinkEvent,
   Configuration,
   CustomEvent,
   Features,

--- a/modules/@shopify/checkout-sheet-kit/src/specs/NativeShopifyCheckoutSheetKit.ts
+++ b/modules/@shopify/checkout-sheet-kit/src/specs/NativeShopifyCheckoutSheetKit.ts
@@ -91,6 +91,7 @@ export interface Spec extends TurboModule {
   isAcceleratedCheckoutAvailable(): boolean;
   isApplePayAvailable(): boolean;
   initiateGeolocationRequest(allow: boolean): void;
+  setClickLinkInterceptionEnabled(enabled: boolean): void;
   addListener(eventName: string): void;
   removeListeners(count: number): void;
   getConstants(): {version: string};

--- a/modules/@shopify/checkout-sheet-kit/tests/index.test.ts
+++ b/modules/@shopify/checkout-sheet-kit/tests/index.test.ts
@@ -489,6 +489,96 @@ describe('ShopifyCheckoutSheetKit', () => {
     });
   });
 
+  describe('clickLink', () => {
+    it('delivers clicked link URLs to the listener', () => {
+      const instance = new ShopifyCheckoutSheet();
+      const callback = jest.fn();
+      instance.addEventListener('clickLink', callback);
+      expect(eventEmitter.addListener).toHaveBeenCalledWith(
+        'clickLink',
+        expect.any(Function),
+      );
+      eventEmitter.emit('clickLink', {url: 'https://shopify.com/account'});
+      expect(callback).toHaveBeenCalledWith({
+        url: 'https://shopify.com/account',
+      });
+    });
+
+    it('parses stringified clickLink event data', () => {
+      const instance = new ShopifyCheckoutSheet();
+      const callback = jest.fn();
+      instance.addEventListener('clickLink', callback);
+      eventEmitter.emit(
+        'clickLink',
+        JSON.stringify({url: 'https://shopify.com/account'}),
+      );
+      expect(callback).toHaveBeenCalledWith({
+        url: 'https://shopify.com/account',
+      });
+    });
+
+    it('enables native interception when the first listener is added', () => {
+      const instance = new ShopifyCheckoutSheet();
+      instance.addEventListener('clickLink', jest.fn());
+      expect(
+        NativeModule.setClickLinkInterceptionEnabled,
+      ).toHaveBeenCalledTimes(1);
+      expect(NativeModule.setClickLinkInterceptionEnabled).toHaveBeenCalledWith(
+        true,
+      );
+
+      // A second listener must not re-enable
+      instance.addEventListener('clickLink', jest.fn());
+      expect(
+        NativeModule.setClickLinkInterceptionEnabled,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables native interception when the last listener is removed', () => {
+      const instance = new ShopifyCheckoutSheet();
+      const first = instance.addEventListener('clickLink', jest.fn());
+      const second = instance.addEventListener('clickLink', jest.fn());
+
+      first?.remove();
+      expect(
+        NativeModule.setClickLinkInterceptionEnabled,
+      ).not.toHaveBeenCalledWith(false);
+
+      second?.remove();
+      expect(
+        NativeModule.setClickLinkInterceptionEnabled,
+      ).toHaveBeenLastCalledWith(false);
+
+      // Removing twice must not decrement below zero
+      second?.remove();
+      expect(
+        NativeModule.setClickLinkInterceptionEnabled,
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    it('disables native interception via removeEventListeners', () => {
+      const instance = new ShopifyCheckoutSheet();
+      instance.addEventListener('clickLink', jest.fn());
+      instance.removeEventListeners('clickLink');
+      expect(eventEmitter.removeAllListeners).toHaveBeenCalledWith(
+        'clickLink',
+      );
+      expect(
+        NativeModule.setClickLinkInterceptionEnabled,
+      ).toHaveBeenLastCalledWith(false);
+    });
+
+    it('does not toggle native interception for other events', () => {
+      const instance = new ShopifyCheckoutSheet();
+      const subscription = instance.addEventListener('close', jest.fn());
+      subscription?.remove();
+      instance.removeEventListeners('close');
+      expect(
+        NativeModule.setClickLinkInterceptionEnabled,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Geolocation', () => {
     const defaultConfig = {};
 

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -50,6 +50,7 @@ import {
 import type {
   CheckoutCompletedEvent,
   CheckoutException,
+  ClickLinkEvent,
   PixelEvent,
 } from '@shopify/checkout-sheet-kit';
 import {ConfigProvider, useConfig} from './context/Config';
@@ -235,11 +236,21 @@ function AppWithContext({children}: PropsWithChildren) {
       },
     );
 
+    // Note: while a 'clickLink' listener is attached, the SDK no longer opens
+    // clicked links itself — the app owns every link tapped in the sheet.
+    const clickLink = shopify.addEventListener(
+      'clickLink',
+      (event: ClickLinkEvent) => {
+        eventHandlers.onClickLink?.(event.url);
+      },
+    );
+
     return () => {
       pixel?.remove();
       completed?.remove();
       close?.remove();
       error?.remove();
+      clickLink?.remove();
     };
   }, [shopify, eventHandlers]);
 


### PR DESCRIPTION
### What changes are you making?

Adds a new `clickLink` event that lets host apps intercept links clicked within checkout that would otherwise be opened outside of it (in the system browser, mail, or phone app).

The native kits already expose this through `checkoutDidClickLink` (iOS) and `onCheckoutLinkClicked` (Android), but the bridge never forwarded it to JS. This wires it through on both platforms.

Native interception is only active while at least one `clickLink` listener is attached: JS counts subscriptions and toggles a native flag via a new `setClickLinkInterceptionEnabled` method (on 0→1 add, off when the last listener is removed). Apps that don't subscribe keep the current default of opening links externally — no behavior change unless you opt in.

Fixes #516

---

### PR Checklist

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
