### PR TITLE
Release 3.8.4 with Cloudflare managed challenge support

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/RNShopifyCheckoutSheetKit.podspec
+++ b/modules/@shopify/checkout-sheet-kit/RNShopifyCheckoutSheetKit.podspec
@@ -20,8 +20,8 @@ Pod::Spec.new do |s|
   s.source_files = "ios/*.{h,m,mm,swift}"
 
 	s.dependency "React-Core"
-	s.dependency "ShopifyCheckoutSheetKit", "= 3.8.1"
-	s.dependency "ShopifyCheckoutSheetKit/AcceleratedCheckouts", "= 3.8.1"
+	s.dependency "ShopifyCheckoutSheetKit", "= 3.8.2"
+	s.dependency "ShopifyCheckoutSheetKit/AcceleratedCheckouts", "= 3.8.2"
 
   if fabric_enabled
 		# Use React Native's helper if available, otherwise add dependencies directly

--- a/modules/@shopify/checkout-sheet-kit/android/gradle.properties
+++ b/modules/@shopify/checkout-sheet-kit/android/gradle.properties
@@ -5,4 +5,4 @@ ndkVersion=23.1.7779620
 buildToolsVersion = "35.0.0"
 
 # Version of Shopify Checkout SDK to use with React Native
-SHOPIFY_CHECKOUT_SDK_VERSION=3.6.1
+SHOPIFY_CHECKOUT_SDK_VERSION=3.6.2

--- a/modules/@shopify/checkout-sheet-kit/package.json
+++ b/modules/@shopify/checkout-sheet-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-sheet-kit",
   "license": "MIT",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "main": "lib/commonjs/index.js",
   "types": "src/index.ts",
   "source": "src/index.ts",

--- a/sample/android/gradle.properties
+++ b/sample/android/gradle.properties
@@ -41,4 +41,4 @@ newArchEnabled=true
 hermesEnabled=true
 
 # Note: only used here for testing
-SHOPIFY_CHECKOUT_SDK_VERSION=3.6.1
+SHOPIFY_CHECKOUT_SDK_VERSION=3.6.2

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -2578,7 +2578,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNShopifyCheckoutSheetKit (3.8.3):
+  - RNShopifyCheckoutSheetKit (3.8.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2605,8 +2605,8 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - ShopifyCheckoutSheetKit (= 3.8.1)
-    - ShopifyCheckoutSheetKit/AcceleratedCheckouts (= 3.8.1)
+    - ShopifyCheckoutSheetKit (= 3.8.2)
+    - ShopifyCheckoutSheetKit/AcceleratedCheckouts (= 3.8.2)
     - SocketRocket
     - Yoga
   - RNVectorIcons (10.3.0):
@@ -2638,11 +2638,11 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ShopifyCheckoutSheetKit (3.8.1):
-    - ShopifyCheckoutSheetKit/Core (= 3.8.1)
-  - ShopifyCheckoutSheetKit/AcceleratedCheckouts (3.8.1):
+  - ShopifyCheckoutSheetKit (3.8.2):
+    - ShopifyCheckoutSheetKit/Core (= 3.8.2)
+  - ShopifyCheckoutSheetKit/AcceleratedCheckouts (3.8.2):
     - ShopifyCheckoutSheetKit/Core
-  - ShopifyCheckoutSheetKit/Core (3.8.1)
+  - ShopifyCheckoutSheetKit/Core (3.8.2)
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
@@ -2996,9 +2996,9 @@ SPEC CHECKSUMS:
   RNGestureHandler: eeb622199ef1fb3a076243131095df1c797072f0
   RNReanimated: 288616f9c66ff4b0911f3862ffcf4104482a2adc
   RNScreens: 3fc29af06302e1f1c18a7829fe57cbc2c0259912
-  RNShopifyCheckoutSheetKit: 8f056ea8ef7fc8116a83c969bf6c024ce49d2dae
+  RNShopifyCheckoutSheetKit: b005993815f6a546aeb9745280ac655046202178
   RNVectorIcons: be4d047a76ad307ffe54732208fb0498fcb8477f
-  ShopifyCheckoutSheetKit: f3bddd39ab853667aaae0fa324eec301ff1c751a
+  ShopifyCheckoutSheetKit: 14273b696ae1943735807893b1a619a5c18b3ab4
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: a742cc68e8366fcfc681808162492bc0aa7a9498
 


### PR DESCRIPTION
## Summary

- Bump @shopify/checkout-sheet-kit to 3.8.4.
- Pin ShopifyCheckoutSheetKit 3.8.2 on iOS.
- Pin checkout-sheet-kit 3.6.2 on Android.
- Render Cloudflare managed challenges for presented React Native checkouts.
- Discard hidden challenge preloads so they are not cached for later presentation.

## Native dependencies

- Swift: https://github.com/Shopify/checkout-sheet-kit-swift/pull/592
- Android: https://github.com/Shopify/checkout-sheet-kit-android/pull/587
