### PR TITLE
Release 3.8.5 with Android 3.6.3

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/android/gradle.properties
+++ b/modules/@shopify/checkout-sheet-kit/android/gradle.properties
@@ -5,4 +5,4 @@ ndkVersion=23.1.7779620
 buildToolsVersion = "35.0.0"
 
 # Version of Shopify Checkout SDK to use with React Native
-SHOPIFY_CHECKOUT_SDK_VERSION=3.6.2
+SHOPIFY_CHECKOUT_SDK_VERSION=3.6.3

--- a/modules/@shopify/checkout-sheet-kit/package.json
+++ b/modules/@shopify/checkout-sheet-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/checkout-sheet-kit",
   "license": "MIT",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "main": "lib/commonjs/index.js",
   "types": "src/index.ts",
   "source": "src/index.ts",

--- a/sample/android/gradle.properties
+++ b/sample/android/gradle.properties
@@ -41,4 +41,4 @@ newArchEnabled=true
 hermesEnabled=true
 
 # Note: only used here for testing
-SHOPIFY_CHECKOUT_SDK_VERSION=3.6.2
+SHOPIFY_CHECKOUT_SDK_VERSION=3.6.3

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -2578,7 +2578,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNShopifyCheckoutSheetKit (3.8.4):
+  - RNShopifyCheckoutSheetKit (3.8.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2996,7 +2996,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: eeb622199ef1fb3a076243131095df1c797072f0
   RNReanimated: 288616f9c66ff4b0911f3862ffcf4104482a2adc
   RNScreens: 3fc29af06302e1f1c18a7829fe57cbc2c0259912
-  RNShopifyCheckoutSheetKit: b005993815f6a546aeb9745280ac655046202178
+  RNShopifyCheckoutSheetKit: 5c79e2ef6a5a81e4b50fb3ba4b1004374a43fbfe
   RNVectorIcons: be4d047a76ad307ffe54732208fb0498fcb8477f
   ShopifyCheckoutSheetKit: 14273b696ae1943735807893b1a619a5c18b3ab4
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748


### PR DESCRIPTION
### What changes are you making?

Prepares `@shopify/checkout-sheet-kit` 3.8.5 with Android Checkout Sheet Kit 3.6.3.

Android 3.6.3 treats main-frame HTTP 429 responses as non-recoverable, matching iOS and preventing the recovery flow from immediately retrying a throttled checkout URL.

Native dependency: https://github.com/Shopify/checkout-sheet-kit-android/pull/588

> [!WARNING]
> Android CI is expected to fail dependency resolution until `com.shopify:checkout-sheet-kit:3.6.3` is published to Maven Central.

### How to test

Given the Android 3.6.3 artifact is available and the React Native sample is configured with a checkout URL whose main frame returns HTTP 429, when the checkout sheet is presented, then the sheet should report one non-recoverable failure and dismiss without retrying the throttled URL.

---

### PR Checklist

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-react-native).
>
> _Releasing a new version of the kit?_
>
> - [x] I have bumped the version number in the [`package.json` file](https://github.com/Shopify/checkout-sheet-kit-react-native/blob/main/modules/%40shopify/checkout-sheet-kit/package.json#L4).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
