### PR TITLE
Fix npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,9 @@ jobs:
           pnpm module clean
           pnpm module build
           cd modules/@shopify/checkout-sheet-kit
-          npm publish --access public --tag ${{ steps.npm-tag.outputs.tag }}
+          pnpm dlx npm@11.5.1 publish --no-git-checks --ignore-scripts --access public --tag "$NPM_TAG" --provenance
         env:
-          NPM_TOKEN: '' # Empty string forces OIDC
+          NPM_TAG: ${{ steps.npm-tag.outputs.tag }}
+          NPM_CONFIG_PROVENANCE: "true"
+          NPM_TOKEN: ""
+          NODE_AUTH_TOKEN: ""


### PR DESCRIPTION
### What changes are you making?
This works confirmed by workflow_dispatch: https://github.com/Shopify/checkout-sheet-kit-react-native/actions/runs/32992451044


Fix npm trusted publishing after the pnpm migration removed the global npm 11 installation.

The publish workflow now mirrors `Shopify/checkout-kit` by:

- running the OIDC-compatible npm 11.5.1 CLI through `pnpm dlx`;
- clearing both npm token environment variables so npm uses GitHub OIDC;
- publishing signed provenance;
- disabling lifecycle scripts and git checks in the privileged publish step.

This fixes the misleading `E404` encountered while publishing 3.9.0.

### How to test

Given `@shopify/checkout-sheet-kit@3.9.0` is not yet published and npm trusted publishing is configured for this repository, when **Publish NPM Package** is manually dispatched against this branch, then the publish step should authenticate through OIDC, record signed provenance, and publish version 3.9.0 under the `latest` tag instead of failing with `E404`.

---

### PR Checklist

- [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CONTRIBUTING.md).
- [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-react-native/blob/main/.github/CODE_OF_CONDUCT.md).
- [ ] I've added tests to support my implementation.
- [ ] I've updated the README.
