### PR TITLE
Omit undefined optional props on AcceleratedCheckoutButtons

### DIFF
--- a/modules/@shopify/checkout-sheet-kit/src/components/AcceleratedCheckoutButtons.tsx
+++ b/modules/@shopify/checkout-sheet-kit/src/components/AcceleratedCheckoutButtons.tsx
@@ -304,12 +304,16 @@ export const AcceleratedCheckoutButtons: React.FC<
   return (
     <RCTAcceleratedCheckoutButtons
       testID="accelerated-checkout-buttons"
-      applePayLabel={applePayLabel}
-      applePayStyle={applePayStyle}
-      style={{...defaultStyles, height: dynamicHeight}}
+      {...(applePayLabel === undefined ? {} : {applePayLabel})}
+      {...(applePayStyle === undefined ? {} : {applePayStyle})}
+      style={
+        dynamicHeight === undefined
+          ? defaultStyles
+          : {...defaultStyles, height: dynamicHeight}
+      }
       checkoutIdentifier={checkoutIdentifier}
-      cornerRadius={cornerRadius}
-      wallets={wallets}
+      {...(cornerRadius === undefined ? {} : {cornerRadius})}
+      {...(wallets === undefined ? {} : {wallets})}
       onFail={handleFail}
       onComplete={handleComplete}
       onCancel={handleCancel}

--- a/modules/@shopify/checkout-sheet-kit/tests/AcceleratedCheckoutButtons.test.tsx
+++ b/modules/@shopify/checkout-sheet-kit/tests/AcceleratedCheckoutButtons.test.tsx
@@ -143,6 +143,28 @@ describe('AcceleratedCheckoutButtons', () => {
       expect(nativeComponent.props.cornerRadius).toBeUndefined();
     });
 
+    it('omits optional props when they are not provided', () => {
+      const {getByTestId} = render(
+        <AcceleratedCheckoutButtons cartId="gid://shopify/Cart/123" />,
+      );
+
+      const nativeComponent = getByTestId('accelerated-checkout-buttons');
+      expect(nativeComponent).toBeTruthy();
+      expect(nativeComponent.props).not.toHaveProperty('applePayLabel');
+      expect(nativeComponent.props).not.toHaveProperty('applePayStyle');
+      expect(nativeComponent.props).not.toHaveProperty('cornerRadius');
+      expect(nativeComponent.props).not.toHaveProperty('wallets');
+    });
+
+    it('omits height from style until a size is reported', () => {
+      const {getByTestId} = render(
+        <AcceleratedCheckoutButtons cartId="gid://shopify/Cart/123" />,
+      );
+
+      const nativeComponent = getByTestId('accelerated-checkout-buttons');
+      expect(nativeComponent.props.style).toEqual({flex: 1});
+    });
+
     it('passes through custom quantity and cornerRadius', () => {
       const {getByTestId} = render(
         <AcceleratedCheckoutButtons

--- a/modules/@shopify/checkout-sheet-kit/tests/AcceleratedCheckoutButtons.test.tsx
+++ b/modules/@shopify/checkout-sheet-kit/tests/AcceleratedCheckoutButtons.test.tsx
@@ -4,6 +4,7 @@ import {Platform} from 'react-native';
 import {
   AcceleratedCheckoutButtons,
   AcceleratedCheckoutWallet,
+  ApplePayLabel,
   ApplePayStyle,
   RenderState,
 } from '../src';
@@ -98,6 +99,7 @@ describe('AcceleratedCheckoutButtons', () => {
           cartId={'gid://shopify/Cart/123'}
           cornerRadius={12}
           wallets={[AcceleratedCheckoutWallet.shopPay]}
+          applePayLabel={ApplePayLabel.buy}
           applePayStyle={ApplePayStyle.black}
         />,
       );
@@ -111,6 +113,7 @@ describe('AcceleratedCheckoutButtons', () => {
       expect(nativeComponent.props.wallets).toEqual([
         AcceleratedCheckoutWallet.shopPay,
       ]);
+      expect(nativeComponent.props.applePayLabel).toBe(ApplePayLabel.buy);
       expect(nativeComponent.props.applePayStyle).toBe(ApplePayStyle.black);
     });
 


### PR DESCRIPTION
## Summary

- Pass `applePayLabel`, `applePayStyle`, `cornerRadius`, and `wallets` to `RCTAcceleratedCheckoutButtons` only when they are defined, instead of always passing them (and therefore `undefined`) to the native component.
- Omit `height` from the style until native reports a size via `onSizeChange`, instead of forcing `height: undefined` into the style on first render.

## Reproduction (3.9.0)

Render `AcceleratedCheckoutButtons` without the optional props, e.g.:

```tsx
<AcceleratedCheckoutButtons
  cartId={cartId}
  onComplete={onComplete}
  onFail={onFail}
/>
```

The wrapper renders the native component with `applePayLabel={undefined}`, `applePayStyle={undefined}`, `cornerRadius={undefined}`, `wallets={undefined}`, and `style={{flex: 1, height: undefined}}`. The `undefined` values are serialized across the JS→native bridge instead of the props simply being absent.

## Root cause

On the native side (iOS, `ios/AcceleratedCheckoutButtons.swift`), the optional props are `@objc var cornerRadius: NSNumber?`, `wallets: [String]?`, `applePayLabel: String?`, `applePayStyle: String?` and the comment above them says the values are intentionally `nil` so that the kit defaults are used. The component relies on distinguishing "prop absent" from "prop present":

- `wallets` explicitly provided and empty means *render nothing* (`wallets != nil && shopifyWallets.isEmpty`); when the prop is absent, the SDK decides the default wallets. An `undefined`/`null` value crossing the bridge does not reliably map to "absent", so the default-wallet fallback can be clobbered.
- `applePayStyle` is always funneled through `PayWithApplePayButtonStyle.from(applePayStyle)` in `updateView()`, so a value that arrives as an unexpected representation of `undefined` can steer the Apple Pay button away from its `automatic` default styling.
- Every `didSet` on these props triggers `updateView()` (and for `wallets`, an intrinsic-content-size invalidation), so explicitly serialized undefined values cause redundant native re-renders at mount.
- `style: {...defaultStyles, height: undefined}` forces an explicit `undefined` height into the Yoga style on first render instead of leaving the height unset until `onSizeChange` reports one.

## Why the fix works

Spreading each optional prop only when it is defined (`{...(prop === undefined ? {} : {prop}})`) keeps the prop absent from the element, which is the representation native already handles correctly as "use the kit default". The same idea applies to `height`: when `dynamicHeight` is `undefined`, we pass `defaultStyles` without a `height` key rather than `height: undefined`.

## Testing

- Added two tests to `tests/AcceleratedCheckoutButtons.test.tsx`:
  - omits `applePayLabel`, `applePayStyle`, `cornerRadius`, and `wallets` from the native element when not provided
  - omits `height` from the style until `onSizeChange` fires (existing test already covers that the reported height is then applied)
- `pnpm test` — 125 tests, 6 suites, all passing
- `pnpm lint` in `modules/@shopify/checkout-sheet-kit` (typecheck + eslint) — passing

## Relationship to #515 / #502

This PR intentionally does **not** touch `flex: 1` / hit-area behavior — that is covered by #515 (fixes #502). The changes here are complementary: #515 makes the reported native height participate in layout, while this PR stops undefined props (including an explicit `undefined` height) from being serialized across the bridge at mount. If both land, the `style` line will need a trivial merge.